### PR TITLE
Check on Fittings 

### DIFF
--- a/OpenHPL/Functions/DarcyFriction/fDarcy.mo
+++ b/OpenHPL/Functions/DarcyFriction/fDarcy.mo
@@ -3,7 +3,7 @@ function fDarcy "Darcy friction factor"
   extends Modelica.Icons.Function;
   input Modelica.SIunits.ReynoldsNumber N_Re "Reynolds number";
   input Modelica.SIunits.Diameter D "Pipe diameter";
-  input Modelica.SIunits.Height p_p_eps "Pipe roughness height";
+  input Modelica.SIunits.Height p_eps "Pipe roughness height";
   // Function output (response) value
   output Real fD "Darcy friction factor";
   // Local (protected) quantities
@@ -14,9 +14,9 @@ protected
   Real X[4, 4], Y[4], K[4];
 algorithm
   X := [N_Re_lam ^ 3, N_Re_lam ^ 2, N_Re_lam, 1; N_Re_tur ^ 3, N_Re_tur ^ 2, N_Re_tur, 1; 3 * N_Re_lam ^ 2, 2 * N_Re_lam, 1, 0; 3 * N_Re_tur ^ 2, 2 * N_Re_tur, 1, 0];
-  Y := {64 / N_Re_lam, 1 / (2 * log10(p_p_eps / 3.7 / D + 5.74 / N_Re_tur ^ 0.9)) ^ 2, -64 / N_Re_lam ^ 2, -0.25 * 0.316 / N_Re_tur ^ 1.25};
+  Y := {64 / N_Re_lam, 1 / (2 * log10(p_eps / 3.7 / D + 5.74 / N_Re_tur ^ 0.9)) ^ 2, -64 / N_Re_lam ^ 2, -0.25 * 0.316 / N_Re_tur ^ 1.25};
   K := Modelica.Math.Matrices.inv(X) * Y;
-  arg := p_p_eps / 3.7 / D + 5.74 / (N_Re + Modelica.Constants.p_eps) ^ 0.9;
+  arg := p_eps / 3.7 / D + 5.74 / (N_Re + Modelica.Constants.eps) ^ 0.9;
   if N_Re <= 0 then
     fD := 0;
   elseif N_Re <= 2100 then

--- a/OpenHPL/Functions/Fitting/FittingVariants/SharpOrifice.mo
+++ b/OpenHPL/Functions/Fitting/FittingVariants/SharpOrifice.mo
@@ -10,9 +10,9 @@ protected
 algorithm
   phi_0 := (1 - (D_o / D_i) ^ 2) * ((D_i / D_o) ^ 4 - 1);
   if N_Re < 2500 then
-    phi := (2.72 + (D_o / D_i) ^ 2 * (120 / (N_Re + Modelica.Constants.p_eps) - 1)) * phi_0;
+    phi := (2.72 + (D_o / D_i) ^ 2 * (120 / (N_Re + Modelica.Constants.eps) - 1)) * phi_0;
   else
-    phi := (2.72 + (D_o / D_i) ^ 2 * 4000 / (N_Re + Modelica.Constants.p_eps)) * phi_0;
+    phi := (2.72 + (D_o / D_i) ^ 2 * 4000 / (N_Re + Modelica.Constants.eps)) * phi_0;
   end if;
   annotation (
     Documentation(info="<html>

--- a/OpenHPL/Tests/Fittings.mo
+++ b/OpenHPL/Tests/Fittings.mo
@@ -1,38 +1,65 @@
 within OpenHPL.Tests;
 model Fittings "Test for comparing fitting behaviour"
   extends Modelica.Icons.Example;
-  OpenHPL.Waterway.Reservoir headw(H_r=10) annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
-  OpenHPL.Waterway.Fitting fitting(fit_type=OpenHPL.Types.Fitting.Square, L=4) annotation (Placement(transformation(extent={{-10,40},{10,60}})));
-  OpenHPL.Waterway.Pipe head(D_i=2) annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
-  OpenHPL.Waterway.Pipe tail(D_i=1) annotation (Placement(transformation(extent={{40,40},{60,60}})));
-  OpenHPL.Waterway.Reservoir tailw(H_r=10) annotation (Placement(transformation(extent={{100,40},{80,60}})));
-  inner OpenHPL.Data data(Steady=true) annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
-  OpenHPL.Waterway.Reservoir headw1(H_r=10) annotation (Placement(transformation(extent={{-100,-10},{-80,10}})));
-  OpenHPL.Waterway.Fitting fitting1(fit_type=OpenHPL.Types.Fitting.Rounded, L=5) annotation (Placement(transformation(extent={{10,-10},{-10,10}})));
-  OpenHPL.Waterway.Pipe head1(D_i=2) annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
-  OpenHPL.Waterway.Pipe tail1(D_i=1) annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-  OpenHPL.Waterway.Reservoir tailw1(H_r=10) annotation (Placement(transformation(extent={{100,-10},{80,10}})));
-  OpenHPL.Waterway.Reservoir headw2(H_r=10) annotation (Placement(transformation(extent={{-100,-40},{-80,-20}})));
-  OpenHPL.Waterway.Pipe head2(D_i=2) annotation (Placement(transformation(extent={{-60,-40},{-40,-20}})));
-  OpenHPL.Waterway.Pipe tail2(D_i=1) annotation (Placement(transformation(extent={{40,-40},{60,-20}})));
-  OpenHPL.Waterway.Reservoir tailw2(H_r=10) annotation (Placement(transformation(extent={{100,-40},{80,-20}})));
-  OpenHPL.Waterway.Pipe fitting2(
-    H=0,
-    L=5,
+  OpenHPL.Waterway.Reservoir Resorvoir1(H_r=10)
+    annotation (Placement(transformation(extent={{-100,40},{-80,60}})));
+  OpenHPL.Waterway.Fitting fittingSquareExpansion(
+    fit_type=OpenHPL.Types.Fitting.Square,
     D_i=2,
-    D_o=1) annotation (Placement(transformation(extent={{-10,-40},{10,-20}})));
+    D_o=4,
+    L=4)
+    "dp = p_i - p_o; So, dp should be positive when the type is expansion."
+    annotation (Placement(transformation(extent={{-10,40},{10,60}})));
+  OpenHPL.Waterway.Pipe pipe1(
+    H=5,
+    L=100,
+    D_i=2) annotation (Placement(transformation(extent={{-60,40},{-40,60}})));
+  OpenHPL.Waterway.Pipe tail1(
+    H=0,
+    L=100,
+    D_i=4) annotation (Placement(transformation(extent={{40,40},{60,60}})));
+  OpenHPL.Waterway.Reservoir tailwater1(H_r=10)
+    annotation (Placement(transformation(extent={{100,40},{80,60}})));
+  inner OpenHPL.Data data(Steady=true) annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+  Waterway.Reservoir Resorvoir2(H_r=10)
+    annotation (Placement(transformation(extent={{-100,12},{-80,32}})));
+  Waterway.Pipe         pipe2(
+    H=5,
+    L=100,
+    D_i=2)                          annotation (Placement(transformation(extent={{-60,12},
+            {-40,32}})));
+  Waterway.Pipe         tail2(
+    H=0,
+    L=100,
+    D_i=4)                          annotation (Placement(transformation(extent={{40,12},
+            {60,32}})));
+  Waterway.Reservoir tailwater2(H_r=10)
+    annotation (Placement(transformation(extent={{100,12},{80,32}})));
+  Waterway.Fitting         fittingSquareExpansion1(
+    fit_type=OpenHPL.Types.Fitting.Square,
+    D_i=4,
+    D_o=2,
+    L=4)
+    "dp = p_i - p_o; So, dp should be positive when the type is expansion."
+    annotation (Placement(transformation(extent={{-10,-10},{10,10}},
+        rotation=180,
+        origin={4,22})));
 equation
-  connect(headw.o, head.i) annotation (Line(points={{-80,50},{-60,50}}, color={28,108,200}));
-  connect(head.o, fitting.i) annotation (Line(points={{-40,50},{-10,50}}, color={28,108,200}));
-  connect(fitting.o, tail.i) annotation (Line(points={{10,50},{40,50}}, color={28,108,200}));
-  connect(tail.o, tailw.o) annotation (Line(points={{60,50},{80,50}}, color={28,108,200}));
-  connect(headw1.o, head1.i) annotation (Line(points={{-80,0},{-60,0}}, color={28,108,200}));
-  connect(head1.o, fitting1.o) annotation (Line(points={{-40,0},{-10,0}}, color={28,108,200}));
-  connect(fitting1.i, tail1.i) annotation (Line(points={{10,0},{40,0}}, color={28,108,200}));
-  connect(tail1.o, tailw1.o) annotation (Line(points={{60,0},{80,0}}, color={28,108,200}));
-  connect(headw2.o, head2.i) annotation (Line(points={{-80,-30},{-60,-30}}, color={28,108,200}));
-  connect(head2.o, fitting2.i) annotation (Line(points={{-40,-30},{-10,-30}}, color={28,108,200}));
-  connect(fitting2.o, tail2.i) annotation (Line(points={{10,-30},{40,-30}}, color={28,108,200}));
-  connect(tail2.o, tailw2.o) annotation (Line(points={{60,-30},{80,-30}}, color={28,108,200}));
+  connect(Resorvoir1.o, pipe1.i)
+    annotation (Line(points={{-80,50},{-60,50}}, color={28,108,200}));
+  connect(pipe1.o, fittingSquareExpansion.i)
+    annotation (Line(points={{-40,50},{-10,50}}, color={28,108,200}));
+  connect(fittingSquareExpansion.o, tail1.i)
+    annotation (Line(points={{10,50},{40,50}}, color={28,108,200}));
+  connect(tail1.o, tailwater1.o)
+    annotation (Line(points={{60,50},{80,50}}, color={28,108,200}));
+  connect(Resorvoir2.o, pipe2.i)
+    annotation (Line(points={{-80,22},{-60,22}}, color={28,108,200}));
+  connect(tail2.o, tailwater2.o)
+    annotation (Line(points={{60,22},{80,22}}, color={28,108,200}));
+  connect(pipe2.o, fittingSquareExpansion1.o)
+    annotation (Line(points={{-40,22},{-6,22}}, color={28,108,200}));
+  connect(tail2.i, fittingSquareExpansion1.i)
+    annotation (Line(points={{40,22},{14,22}}, color={28,108,200}));
   annotation (experiment(StopTime=100));
 end Fittings;

--- a/OpenHPL/Tests/HPSTAirCushion.mo
+++ b/OpenHPL/Tests/HPSTAirCushion.mo
@@ -26,11 +26,7 @@ model HPSTAirCushion "Test for Air cushion surge tank"
         origin={30,10},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  inner OpenHPL.Parameters para annotation (Placement(visible=true, transformation(
-        origin={-90,90},
-        extent={{-10,-10},{10,10}},
-        rotation=0)));
-  Waterway.SurgeTank STAirCushion(surge_tank_type=OpenHPL.Types.SurgeTank.STAirCushion)
+  Waterway.SurgeTank STAirCushion(SurgeTankType=OpenHPL.Types.SurgeTank.STAirCushion)
     annotation (Placement(transformation(extent={{-42,20},{-22,40}})));
 equation
   connect(turbine.o, discharge.i) annotation (

--- a/OpenHPL/Tests/HPSTSharpOrifice.mo
+++ b/OpenHPL/Tests/HPSTSharpOrifice.mo
@@ -26,12 +26,11 @@ model HPSTSharpOrifice "Test for sharp orifice surge tank"
         origin={30,10},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  inner OpenHPL.Parameters para annotation (Placement(visible=true, transformation(
-        origin={-90,90},
-        extent={{-10,-10},{10,10}},
-        rotation=0)));
-  Waterway.SurgeTank STSharpOrifice(surge_tank_type=OpenHPL.Types.SurgeTank.STSharpOrifice)
+  Waterway.SurgeTank STSharpOrifice(SurgeTankType=OpenHPL.Types.SurgeTank.STSharpOrifice,
+                                    surge_tank_type=OpenHPL.Types.SurgeTank.STSharpOrifice)
     annotation (Placement(transformation(extent={{-42,20},{-22,40}})));
+  inner Data data
+    annotation (Placement(transformation(extent={{-98,82},{-78,102}})));
 equation
   connect(turbine.o, discharge.i) annotation (
     Line(points={{40,10},{44,10},{44,0},{50,0}},            color = {28, 108, 200}));

--- a/OpenHPL/Tests/HPSTSimple.mo
+++ b/OpenHPL/Tests/HPSTSimple.mo
@@ -27,12 +27,10 @@ model HPSTSimple
         origin={30,10},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  inner OpenHPL.Parameters para annotation (Placement(visible=true, transformation(
-        origin={-90,90},
-        extent={{-10,-10},{10,10}},
-        rotation=0)));
   Waterway.SurgeTank STSimple
     annotation (Placement(transformation(extent={{-42,20},{-22,40}})));
+  inner Data data
+    annotation (Placement(transformation(extent={{-96,80},{-76,100}})));
 equation
   connect(turbine.o, discharge.i) annotation (
     Line(points={{40,10},{44,10},{44,0},{50,0}},            color = {28, 108, 200}));

--- a/OpenHPL/Tests/HPSTThrottleValve.mo
+++ b/OpenHPL/Tests/HPSTThrottleValve.mo
@@ -26,12 +26,10 @@ model HPSTThrottleValve "Test for throttle valve surge tank"
         origin={30,10},
         extent={{-10,-10},{10,10}},
         rotation=0)));
-  inner OpenHPL.Parameters para annotation (Placement(visible=true, transformation(
-        origin={-90,90},
-        extent={{-10,-10},{10,10}},
-        rotation=0)));
   Waterway.SurgeTank STThrottleValve(surge_tank_type=OpenHPL.Types.SurgeTank.STThrottleValve)
     annotation (Placement(transformation(extent={{-42,20},{-22,40}})));
+  inner Data data
+    annotation (Placement(transformation(extent={{-96,80},{-76,100}})));
 equation
   connect(turbine.o, discharge.i) annotation (
     Line(points={{40,10},{44,10},{44,0},{50,0}},            color = {28, 108, 200}));


### PR DESCRIPTION
Fittings does not work as expected when element is rotated because we misinterpret input and output diameter. The solution would be to use both expansion and reduction symbol in the icon to avoid confusion so that user can only choose the input and output diameter and do not need to rotate the element.