### PR TITLE
feat: Add automatic elevation propagation

### DIFF
--- a/OpenHPL/Data.mo
+++ b/OpenHPL/Data.mo
@@ -1,6 +1,9 @@
 within OpenHPL;
 record Data "Provides a data set of most common used settings"
   extends Modelica.Icons.Record;
+  parameter Boolean showElevation=true "Display elevation of connectors"
+    annotation(Dialog(group = "Icon"),
+    choices(checkBox = true)); 
   parameter SI.Acceleration g = Modelica.Constants.g_n "Gravity constant"
     annotation (Dialog(enable=false, group = "Constants"));
   parameter Real gamma_air = 1.4 "Ratio of heat capacities at constant pressure (C_p) to constant volume (C_v) for air at STP"

--- a/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
+++ b/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
@@ -34,6 +34,7 @@ equation
   Vdot = mdot/data.rho;
   dp*(C_v_*max(epsilon, u^alpha))^2 = Vdot*abs(Vdot) "Valve equation for pressure drop";
   dp = i.p - o.p "Link the pressure drop to the ports";
+  o.z = i.z "Elevation propagation: no height change across valve";
   annotation (preferredView="info", Documentation(info="<html>
 <p>
 This is a partial, simple model of hydraulic valve. &nbsp;</p><p>This model is based on the energy balance of a valve.

--- a/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
+++ b/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
@@ -28,14 +28,13 @@ protected
     annotation (Placement(transformation(origin = {0, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 270), iconTransformation(extent = {{-20, -20}, {20, 20}}, rotation = 270, origin = {0, 80})));
   constant Real epsilon = 5.0e-5 "Constant to ensure robust expression for dp vs flow. Trial and error to find suitable value.";
 
-initial equation
-  o.z = i.z "Elevation propagation: no height change across valve";
 equation
   i.mdot + o.mdot = 0;
   mdot = i.mdot;
   Vdot = mdot/data.rho;
   dp*(C_v_*max(epsilon, u^alpha))^2 = Vdot*abs(Vdot) "Valve equation for pressure drop";
   dp = i.p - o.p "Link the pressure drop to the ports";
+  o.z = i.z "Elevation propagation: no height change across valve";
   annotation (preferredView="info", Documentation(info="<html>
 <p>
 This is a partial, simple model of hydraulic valve. &nbsp;</p><p>This model is based on the energy balance of a valve.

--- a/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
+++ b/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
@@ -28,13 +28,14 @@ protected
     annotation (Placement(transformation(origin = {0, 70}, extent = {{-10, -10}, {10, 10}}, rotation = 270), iconTransformation(extent = {{-20, -20}, {20, 20}}, rotation = 270, origin = {0, 80})));
   constant Real epsilon = 5.0e-5 "Constant to ensure robust expression for dp vs flow. Trial and error to find suitable value.";
 
+initial equation
+  o.z = i.z "Elevation propagation: no height change across valve";
 equation
   i.mdot + o.mdot = 0;
   mdot = i.mdot;
   Vdot = mdot/data.rho;
   dp*(C_v_*max(epsilon, u^alpha))^2 = Vdot*abs(Vdot) "Valve equation for pressure drop";
   dp = i.p - o.p "Link the pressure drop to the ports";
-  o.z = i.z "Elevation propagation: no height change across valve";
   annotation (preferredView="info", Documentation(info="<html>
 <p>
 This is a partial, simple model of hydraulic valve. &nbsp;</p><p>This model is based on the energy balance of a valve.

--- a/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
+++ b/OpenHPL/ElectroMech/BaseClasses/BaseValve.mo
@@ -34,7 +34,7 @@ equation
   Vdot = mdot/data.rho;
   dp*(C_v_*max(epsilon, u^alpha))^2 = Vdot*abs(Vdot) "Valve equation for pressure drop";
   dp = i.p - o.p "Link the pressure drop to the ports";
-  o.z = i.z "Elevation propagation: no height change across valve";
+  o.elevation.z = i.elevation.z "Elevation propagation: no height change across valve";
   annotation (preferredView="info", Documentation(info="<html>
 <p>
 This is a partial, simple model of hydraulic valve. &nbsp;</p><p>This model is based on the energy balance of a valve.

--- a/OpenHPL/ElectroMech/Turbines/Francis.mo
+++ b/OpenHPL/ElectroMech/Turbines/Francis.mo
@@ -210,6 +210,7 @@ equation
     p_tr2 = o.p;
     i.mdot+o.mdot=0;
     mdot=i.mdot;
+    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Francis.mo
+++ b/OpenHPL/ElectroMech/Turbines/Francis.mo
@@ -210,7 +210,7 @@ equation
     p_tr2 = o.p;
     i.mdot+o.mdot=0;
     mdot=i.mdot;
-    o.z = i.z "Elevation propagation: no height change across turbine";
+    o.elevation.z = i.elevation.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Francis.mo
+++ b/OpenHPL/ElectroMech/Turbines/Francis.mo
@@ -79,6 +79,7 @@ model Francis "Model of the Francis turbine"
     Real W_t2_n "Euler second term, nominal", W_t1_n "Euler first term, nominal", Wdot_t_n "Total power, nominal", cot_a1_n "Cotant nominal alpha", Vdot_n_ = Vdot_n / 0.99 "Flow rate for fully open guide vane", d_n(start = 0.67) "Nominal servo term", theta_n "Servo angle for fully open guide vane";
     SI.Angle alpha1_n "Nominal inlet guide vane angle";
     // connectors
+    extends OpenHPL.Interfaces.TwoContacts;
     extends OpenHPL.Interfaces.TurbineContacts(enable_P_out=true);
     Modelica.Blocks.Interfaces.RealInput w_in "Input angular velocity from the generator" annotation (
                                 Placement(transformation(origin={-120,-80}, extent={{-20,-20},

--- a/OpenHPL/ElectroMech/Turbines/Francis.mo
+++ b/OpenHPL/ElectroMech/Turbines/Francis.mo
@@ -88,8 +88,6 @@ protected
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={40,90})));
-initial equation
-  o.z = i.z "Elevation propagation: no height change across turbine";
 equation
   // design algorithm for runner
     if GivenData then
@@ -212,6 +210,7 @@ equation
     p_tr2 = o.p;
     i.mdot+o.mdot=0;
     mdot=i.mdot;
+    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Francis.mo
+++ b/OpenHPL/ElectroMech/Turbines/Francis.mo
@@ -88,6 +88,8 @@ protected
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={40,90})));
+initial equation
+  o.z = i.z "Elevation propagation: no height change across turbine";
 equation
   // design algorithm for runner
     if GivenData then
@@ -210,7 +212,6 @@ equation
     p_tr2 = o.p;
     i.mdot+o.mdot=0;
     mdot=i.mdot;
-    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Pelton.mo
+++ b/OpenHPL/ElectroMech/Turbines/Pelton.mo
@@ -54,6 +54,7 @@ equation
   // Flow rate connectors
     i.mdot+o.mdot=0;
     mdot=i.mdot;
+    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Pelton.mo
+++ b/OpenHPL/ElectroMech/Turbines/Pelton.mo
@@ -30,6 +30,8 @@ protected
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={40,90})));
+initial equation
+  o.z = i.z "Elevation propagation: no height change across turbine";
 equation
   // Condition for inlet water compressibility
     if not CompElas then
@@ -54,7 +56,6 @@ equation
   // Flow rate connectors
     i.mdot+o.mdot=0;
     mdot=i.mdot;
-    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Pelton.mo
+++ b/OpenHPL/ElectroMech/Turbines/Pelton.mo
@@ -54,7 +54,7 @@ equation
   // Flow rate connectors
     i.mdot+o.mdot=0;
     mdot=i.mdot;
-    o.z = i.z "Elevation propagation: no height change across turbine";
+    o.elevation.z = i.elevation.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Pelton.mo
+++ b/OpenHPL/ElectroMech/Turbines/Pelton.mo
@@ -30,8 +30,6 @@ protected
         extent={{-10,-10},{10,10}},
         rotation=90,
         origin={40,90})));
-initial equation
-  o.z = i.z "Elevation propagation: no height change across turbine";
 equation
   // Condition for inlet water compressibility
     if not CompElas then
@@ -56,6 +54,7 @@ equation
   // Flow rate connectors
     i.mdot+o.mdot=0;
     mdot=i.mdot;
+    o.z = i.z "Elevation propagation: no height change across turbine";
 
   connect(p_out, P_out) annotation (Line(points={{40,90},{40,110}}, color={0,0,127}));
     annotation (preferredView="info",

--- a/OpenHPL/ElectroMech/Turbines/Pelton.mo
+++ b/OpenHPL/ElectroMech/Turbines/Pelton.mo
@@ -21,6 +21,7 @@ model Pelton "Model of the Pelton turbine"
     SI.AngularVelocity w=w_in "Angular velocity";
     Real cos_b = Modelica.Math.cos(Modelica.Units.Conversions.from_deg(beta));
     // connectors
+    extends OpenHPL.Interfaces.TwoContacts;
     extends OpenHPL.Interfaces.TurbineContacts(enable_P_out=true);
     Modelica.Blocks.Interfaces.RealInput w_in "Input angular velocity from the generator" annotation (
                                 Placement(transformation(origin={-120,-80}, extent={{-20,-20},

--- a/OpenHPL/Examples/BranchingPipes.mo
+++ b/OpenHPL/Examples/BranchingPipes.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples;
 model BranchingPipes "Model of branching pipes"
   extends Modelica.Icons.Example;
-  Waterway.Reservoir reservoir annotation (
+  Waterway.Reservoir reservoir(fixElevation = true, z_0 = 3)  annotation (
     Placement(transformation(extent = {{-80, -10}, {-60, 10}})));
   Waterway.Pipe mainPipe(D_i = 6, H = 1, L = 100) annotation (
     Placement(transformation(extent = {{-52, -10}, {-32, 10}})));
@@ -9,24 +9,24 @@ model BranchingPipes "Model of branching pipes"
     Placement(transformation(extent = {{-10, -10}, {10, 10}}, rotation = 180, origin = {70, 0})));
   Waterway.Pipe branch1(D_i = 3, H = 1, L = 100, Vdot_0 = data.Vdot_0/2) annotation (
     Placement(transformation(extent = {{-10, 10}, {10, 30}})));
-  Waterway.Pipe branch2(D_i = 3, H = 1, L = 100, Vdot_0 = data.Vdot_0/2) annotation (
+  Waterway.Pipe branch2(D_i = 3, H = 1, L = 100, Vdot_0 = data.Vdot_0/2) annotation(
     Placement(transformation(extent = {{-10, -30}, {10, -10}})));
   Waterway.Pipe mainPipeOut(D_i = 5, H = 1, L = 100) annotation (
     Placement(transformation(extent = {{30, -10}, {50, 10}})));
   inner Data data(SteadyState = true, Vdot_0 = 75) annotation (
     Placement(transformation(extent = {{-100, 80}, {-80, 100}})));
 equation
-  connect(reservoir.o, mainPipe.i) annotation (
+  connect(reservoir.o, mainPipe.i) annotation(
     Line(points = {{-60, 0}, {-52, 0}}, color = {28, 108, 200}));
-  connect(branch1.i, mainPipe.o) annotation (
+  connect(branch1.i, mainPipe.o) annotation(
     Line(points = {{-10, 20}, {-20, 20}, {-20, 0}, {-32, 0}}, color = {28, 108, 200}));
-  connect(mainPipe.o, branch2.i) annotation (
+  connect(mainPipe.o, branch2.i) annotation(
     Line(points = {{-32, 0}, {-20, 0}, {-20, -20}, {-10, -20}}, color = {28, 108, 200}));
-  connect(branch2.o, mainPipeOut.i) annotation (
+  connect(branch2.o, mainPipeOut.i) annotation(
     Line(points = {{10, -20}, {20, -20}, {20, 0}, {30, 0}}, color = {28, 108, 200}));
-  connect(branch1.o, mainPipeOut.i) annotation (
+  connect(branch1.o, mainPipeOut.i) annotation(
     Line(points = {{10, 20}, {20, 20}, {20, 0}, {30, 0}}, color = {28, 108, 200}));
-  connect(mainPipeOut.o, reservoir1.o) annotation (
+  connect(mainPipeOut.o, reservoir1.o) annotation(
     Line(points = {{50, 0}, {60, 0}}, color = {0, 128, 255}));
   annotation (
     experiment(StopTime = 2000, StartTime = 0, Tolerance = 0.0001, Interval = 0.4));

--- a/OpenHPL/Examples/DetailedTurbine.mo
+++ b/OpenHPL/Examples/DetailedTurbine.mo
@@ -2,5 +2,5 @@ within OpenHPL.Examples;
 model DetailedTurbine "Hydropower system using KP scheme based penstock"
   extends SimpleTurbine(
                  redeclare Waterway.PenstockKP penstock);
-  annotation (experiment(StopTime=1000));
+  annotation (experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2));
 end DetailedTurbine;

--- a/OpenHPL/Examples/Gate.mo
+++ b/OpenHPL/Examples/Gate.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples;
 model Gate "Usage of the tainter gate"
   extends Modelica.Icons.Example;
-  inner Data data(SteadyState = true, Vdot_0 = 75) annotation (
+  inner Data data(SteadyState = true, Vdot_0 = 75, showElevation = false) annotation (
     Placement(transformation(extent = {{-100, 80}, {-80, 100}})));
   Modelica.Blocks.Sources.Ramp gateOpening(
     height=0,
@@ -12,7 +12,7 @@ model Gate "Usage of the tainter gate"
     constantLevel=false,
     useLevel=true,
     L=10,
-    W=10) annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
+    W=10, fixElevation = true) annotation (Placement(transformation(extent={{-40,40},{-20,60}})));
   Waterway.Reservoir downstream(
     h_0=4,
     constantLevel=false,
@@ -32,7 +32,7 @@ model Gate "Usage of the tainter gate"
     constantLevel=false,
     useLevel=true,
     L=10,
-    W=10) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
+    W=10, fixElevation = true) annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   Waterway.Reservoir downstream1(
     h_0=4,
     constantLevel=false,
@@ -51,7 +51,7 @@ model Gate "Usage of the tainter gate"
     constantLevel=false,
     useLevel=true,
     L=10,
-    W=10) annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
+    W=10, fixElevation = true) annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
   Waterway.Reservoir downstream2(
     h_0=4,
     constantLevel=false,

--- a/OpenHPL/Examples/Pipes.mo
+++ b/OpenHPL/Examples/Pipes.mo
@@ -5,26 +5,26 @@ model Pipes "Example of contracting, contstant and expanding pipe diameters"
     inner OpenHPL.Data data annotation (
       Placement(transformation(origin={-90,90}, extent={{-10,-10},{10,10}})));
     parameter SI.Diameter Dn=0.3568 "Nominal Diameter";
-    Waterway.Reservoir Upstream(h_0 = 100.0, constantLevel=true)
+    Waterway.Reservoir Upstream(h_0 = 100.0, constantLevel=true, fixElevation = true, z_0 = 50)
                                                             annotation (
       Placement(transformation(origin={-50,0}, extent={{-10,-10},{10,10}})));
-    Waterway.Reservoir Downstream(h_0 = 0.0, constantLevel=true)
+    Waterway.Reservoir Downstream(h_0 = 0.0, constantLevel=true, z_0 = 30, fixElevation = true)
                                                                annotation (
       Placement(transformation(origin={50,0}, extent={{10,-10},{-10,10}}, rotation = -0)));
     OpenHPL.Waterway.Pipe pipeExpanding(
     D_i=0.8*Dn,
     D_o=1.2*Dn,
-    H=0,
+    H= 10,
     L=1000) annotation (Placement(transformation(origin={0,20}, extent={{-10,-10},{10,10}})));
     OpenHPL.Waterway.Pipe pipeConstant(
     D_i=Dn,
     D_o=Dn,
-    H=0,
+    H= 20,
     L=1000) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
     OpenHPL.Waterway.Pipe pipeContracting(
     D_i=1.2*Dn,
     D_o=0.8*Dn,
-    H=0,
+    H= 30,
     L=1000) annotation (Placement(transformation(origin={0,-20}, extent={{-10,-10},{10,10}})));
 
 equation

--- a/OpenHPL/Examples/Pipes.mo
+++ b/OpenHPL/Examples/Pipes.mo
@@ -5,10 +5,10 @@ model Pipes "Example of contracting, contstant and expanding pipe diameters"
     inner OpenHPL.Data data annotation (
       Placement(transformation(origin={-90,90}, extent={{-10,-10},{10,10}})));
     parameter SI.Diameter Dn=0.3568 "Nominal Diameter";
-    Waterway.Reservoir Upstream(h_0 = 100.0, constantLevel=true, fixElevation = true, z_0 = 50)
+    Waterway.Reservoir Upstream(h_0 = 100.0, constantLevel=true, fixElevation = true, z_0 = 10)
                                                             annotation (
       Placement(transformation(origin={-50,0}, extent={{-10,-10},{10,10}})));
-    Waterway.Reservoir Downstream(h_0 = 0.0, constantLevel=true, z_0 = 30, fixElevation = true)
+    Waterway.Reservoir Downstream(h_0 = 0.0, constantLevel=true, fixElevation = false)
                                                                annotation (
       Placement(transformation(origin={50,0}, extent={{10,-10},{-10,10}}, rotation = -0)));
     OpenHPL.Waterway.Pipe pipeExpanding(
@@ -19,12 +19,12 @@ model Pipes "Example of contracting, contstant and expanding pipe diameters"
     OpenHPL.Waterway.Pipe pipeConstant(
     D_i=Dn,
     D_o=Dn,
-    H= 20,
+    H= 10,
     L=1000) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
     OpenHPL.Waterway.Pipe pipeContracting(
     D_i=1.2*Dn,
     D_o=0.8*Dn,
-    H= 30,
+    H= 10,
     L=1000) annotation (Placement(transformation(origin={0,-20}, extent={{-10,-10},{10,10}})));
 
 equation

--- a/OpenHPL/Examples/SimpleGen.mo
+++ b/OpenHPL/Examples/SimpleGen.mo
@@ -1,9 +1,7 @@
 within OpenHPL.Examples;
 model SimpleGen "Model of a hydropower system with a simple turbine turbine and generator"
   extends SimpleTurbine(
-                 turbine(
-      enable_nomSpeed=false,
-      enable_P_out=true));
+                 turbine(enable_nomSpeed = false, enable_P_out = true), reservoir(fixElevation = true, z_0 = 100));
   ElectroMech.Generators.SimpleGen simpleGen annotation (Placement(transformation(extent={{20,50},{40,70}})));
   Modelica.Blocks.Math.Gain loadLevel(k=1) annotation (Placement(transformation(extent={{72,70},{52,90}})));
 equation
@@ -12,5 +10,5 @@ equation
   connect(simpleGen.flange, turbine.flange) annotation (Line(
       points={{30,60},{30,10}},
       color={0,0,0}));
-  annotation (experiment(StopTime=1000));
+  annotation (experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2));
 end SimpleGen;

--- a/OpenHPL/Examples/SimpleGenFrancis.mo
+++ b/OpenHPL/Examples/SimpleGenFrancis.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples;
 model SimpleGenFrancis "Model of a hydropower system with Francis turbine model"
   extends Modelica.Icons.Example;
-  Waterway.Reservoir reservoir(h_0=48) annotation (Placement(transformation(
+  Waterway.Reservoir reservoir(h_0 = 48, fixElevation = true) annotation (Placement(transformation(
         origin={-90,50},
         extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Ramp control(
@@ -57,7 +57,7 @@ model SimpleGenFrancis "Model of a hydropower system with Francis turbine model"
               annotation (Placement(transformation(
         origin={30,0},
         extent={{-10,-10},{10,10}})));
-  inner OpenHPL.Data data(Vdot_0=4.54) annotation (Placement(transformation(
+  inner OpenHPL.Data data(SteadyState = false)  annotation (Placement(transformation(
         origin={-90,90},
         extent={{-10,-10},{10,10}})));
   Waterway.Fitting fitting(
@@ -86,5 +86,5 @@ equation
     Line(points={{80,6.66134e-16},{80,0},{70,0}}, color = {28, 108, 200}));
   connect(penstock.o, fitting.i) annotation (
     Line(points={{-20,0},{-12,0}}, color = {28, 108, 200}));
-  annotation (experiment(StopTime=1000));
+  annotation (experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2));
 end SimpleGenFrancis;

--- a/OpenHPL/Examples/SimpleTurbine.mo
+++ b/OpenHPL/Examples/SimpleTurbine.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples;
 model SimpleTurbine "Model of a hydropower system with a simple turbine turbine"
   extends Modelica.Icons.Example;
-  OpenHPL.Waterway.Reservoir reservoir(h_0=10) annotation (Placement(transformation(
+  OpenHPL.Waterway.Reservoir reservoir(h_0 = 10, fixElevation = true, z_0 = 100) annotation (Placement(transformation(
         origin={-90,30},
         extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Ramp control(
@@ -45,5 +45,5 @@ equation
     Line(points={{-50,30},{-40,30}}, color = {28, 108, 200}));
   connect(surgeTank.o, penstock.i) annotation (Line(points={{-20,30},{-10,30}}, color={28,108,200}));
   connect(discharge.o, tail.o) annotation (Line(points={{70,0},{80,0}}, color={28,108,200}));
-  annotation (experiment(StopTime=1000));
+  annotation (experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2));
 end SimpleTurbine;

--- a/OpenHPL/Examples/SimpleValve.mo
+++ b/OpenHPL/Examples/SimpleValve.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples;
 model SimpleValve "Model of a hydropower system with a simple turbine turbine"
   extends Modelica.Icons.Example;
-  OpenHPL.Waterway.Reservoir reservoir(h_0=10) annotation (Placement(transformation(
+  OpenHPL.Waterway.Reservoir reservoir(h_0 = 10, fixElevation = true, z_0 = 100) annotation (Placement(transformation(
         origin={-90,30},
         extent={{-10,-10},{10,10}})));
   Modelica.Blocks.Sources.Ramp control(
@@ -46,7 +46,7 @@ equation
   connect(penstock.o, valve.i) annotation (Line(points={{10,30},{20,30}}, color={0,128,255}));
   connect(valve.o, discharge.i) annotation (Line(points={{40,30},{50,30}}, color={0,128,255}));
   connect(control.y, valve.opening) annotation (Line(points={{1,70},{30,70},{30,38}}, color={0,0,127}));
-  annotation (experiment(StopTime=1000), Documentation(info="<html>
+  annotation (experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2), Documentation(info="<html>
 <p>
 Simple model of a water way with only a valve component.
 This can be used to investigate the effect of different opening and closing times in the waterway.

--- a/OpenHPL/Examples/SimpleValveWithCreek.mo
+++ b/OpenHPL/Examples/SimpleValveWithCreek.mo
@@ -2,7 +2,7 @@ within OpenHPL.Examples;
 model SimpleValveWithCreek
   "Model of a hydropower system with a simple turbine turbine"
   extends Modelica.Icons.Example;
-  Waterway.Reservoir reservoir(h_0 = 10, constantLevel = false) annotation(
+  Waterway.Reservoir reservoir(h_0 = 10, constantLevel = false, fixElevation = true, z_0 = 110) annotation(
     Placement(transformation(origin = {-90, 30}, extent = {{-10, -10}, {10, 10}})));
   Modelica.Blocks.Sources.Ramp control(duration = 30, height = 0.5, offset = 0, startTime = 500e6) annotation(
     Placement(transformation(origin={-10,0},    extent = {{-10, -10}, {10, 10}})));
@@ -15,7 +15,7 @@ model SimpleValveWithCreek
   replaceable Waterway.Pipe penstock(D_i = 3, D_o = 3, H = 80, L = 200, vertical = true)
                                                                                   constrainedby Interfaces.TwoContacts annotation(
      Placement(transformation(origin={60,30},   extent = {{-10, -10}, {10, 10}})));
-  Waterway.SurgeTank creekIntake(H = 25, L = 30, h_0 = 20, useCreekIntake = true) annotation(
+  Waterway.SurgeTank creekIntake(H = 25, L = 30, h_0 = 20) annotation(
     Placement(transformation(origin = {-30, 30}, extent = {{-10, -10}, {10, 10}})));
   inner Data data(Vdot_0 = 0) annotation(
     Placement(transformation(origin = {-90, 90}, extent = {{-10, -10}, {10, 10}})));
@@ -49,7 +49,7 @@ equation
   connect(penstock.o, valve.i) annotation (Line(points={{70,30},{80,30},{80,10},
           {8,10},{8,-20},{20,-20}}, color={0,128,255}));
   annotation(
-    experiment(StopTime = 1000),
+    experiment(StopTime = 1000, StartTime = 0, Tolerance = 1e-06, Interval = 2),
     Documentation(info = "<html>
 <p>
 Simple model of a water way with one creek intake.

--- a/OpenHPL/Examples/VolumeFlowSource.mo
+++ b/OpenHPL/Examples/VolumeFlowSource.mo
@@ -2,7 +2,7 @@ within OpenHPL.Examples;
 model VolumeFlowSource "Example demonstrating the use of VolumeFlowSource"
   extends Modelica.Icons.Example;
   OpenHPL.Waterway.Reservoir tail1 annotation (Placement(transformation(extent={{60,30},{40,50}})));
-  inner OpenHPL.Data data(SteadyState = false, Vdot_0 = 1, showElevation = false)  annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+  inner OpenHPL.Data data(SteadyState = false, Vdot_0 = 1, showElevation = true)  annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
   OpenHPL.Waterway.VolumeFlowSource volumeFlowConstant(fixElevation = true)  annotation (Placement(transformation(extent={{-50,30},{-30,50}})));
   Waterway.Pipe pipe1(H=0) annotation (Placement(transformation(extent={{-10,30},{10,50}})));
   Waterway.Pipe pipe2(H=0) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
@@ -27,5 +27,5 @@ equation
   connect(pipe3.o,tail3. o) annotation (Line(points={{10,-40},{40,-40}},
                                                                      color={0,128,255}));
   connect(volumeFlowFiltered.outFlow, logdata.y[1]) annotation (Line(points={{-50,-40},{-59,-40}}, color={0,0,127}));
-  annotation (experiment(StopTime=120));
+  annotation (experiment(StopTime = 120, StartTime = 0, Tolerance = 1e-06, Interval = 0.24));
 end VolumeFlowSource;

--- a/OpenHPL/Examples/VolumeFlowSource.mo
+++ b/OpenHPL/Examples/VolumeFlowSource.mo
@@ -2,21 +2,21 @@ within OpenHPL.Examples;
 model VolumeFlowSource "Example demonstrating the use of VolumeFlowSource"
   extends Modelica.Icons.Example;
   OpenHPL.Waterway.Reservoir tail1 annotation (Placement(transformation(extent={{60,30},{40,50}})));
-  inner OpenHPL.Data data annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
-  OpenHPL.Waterway.VolumeFlowSource volumeFlowConstant annotation (Placement(transformation(extent={{-50,30},{-30,50}})));
+  inner OpenHPL.Data data(SteadyState = false, Vdot_0 = 1, showElevation = false)  annotation (Placement(transformation(extent={{-100,80},{-80,100}})));
+  OpenHPL.Waterway.VolumeFlowSource volumeFlowConstant(fixElevation = true)  annotation (Placement(transformation(extent={{-50,30},{-30,50}})));
   Waterway.Pipe pipe1(H=0) annotation (Placement(transformation(extent={{-10,30},{10,50}})));
   Waterway.Pipe pipe2(H=0) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.Reservoir tail2 annotation (Placement(transformation(extent={{60,-10},{40,10}})));
-  OpenHPL.Waterway.VolumeFlowSource volumeFlowInput(useInput=true, useFilter=false) annotation (Placement(transformation(extent={{-48,-10},{-28,10}})));
-  Modelica.Blocks.Sources.Sine sine(f=0.01) annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
-  Modelica.Blocks.Sources.CombiTimeTable logdata(table=[1,0.256342739; 2,0.245221436; 3,0.266113698; 4,0.249561667; 5,0.525063097; 6,0.479064316; 7,0.494991362; 8,0.489708632; 9,0.50391084; 10,0.492354929; 11,0.509279788; 12,0.495274216; 13,0.493877858; 14,0.520679474; 15,0.499932915; 16,0.494227827; 17,0.472558141; 18,0.441845328; 19,0.398698032; 20,0.369865984; 21,0.341512531; 22,0.317958236; 23,0.300121665; 24,0.283421665; 25,0.271103382; 26,0.29000932; 27,0.276437521; 28,0.279719085; 29,0.273819894;
+  OpenHPL.Waterway.VolumeFlowSource volumeFlowInput(useInput=true, useFilter= false, fixElevation = true) annotation (Placement(transformation(extent={{-48,-10},{-28,10}})));
+  Modelica.Blocks.Sources.Sine sine(f = 0.01, offset = 1) annotation (Placement(transformation(extent={{-80,-10},{-60,10}})));
+  Modelica.Blocks.Sources.CombiTimeTable logdata(table=[1, 1; 2,0.245221436; 3,0.266113698; 4,0.249561667; 5,0.525063097; 6,0.479064316; 7,0.494991362; 8,0.489708632; 9,0.50391084; 10,0.492354929; 11,0.509279788; 12,0.495274216; 13,0.493877858; 14,0.520679474; 15,0.499932915; 16,0.494227827; 17,0.472558141; 18,0.441845328; 19,0.398698032; 20,0.369865984; 21,0.341512531; 22,0.317958236; 23,0.300121665; 24,0.283421665; 25,0.271103382; 26,0.29000932; 27,0.276437521; 28,0.279719085; 29,0.273819894;
         30,0.530646265; 31,0.494690746; 32,0.668753743; 33,0.748319328; 34,1.156479597; 35,1.622769237; 36,1.455329537; 37,1.440503478; 38,1.388660312; 39,1.321571827; 40,1.428969026; 41,1.335716724; 42,1.240077496; 43,1.147016048; 44,1.046641827; 45,0.957466781; 46,0.877434254; 47,0.760209978; 48,0.685476542; 49,0.611937046; 50,0.5434497; 51,0.486470848; 52,0.437200874; 53,0.387043357; 54,0.346913666; 55,0.321531206; 56,0.3025949; 57,0.289946347; 58,0.76049149; 59,1.301532745; 60,1.66047287; 61,
         1.468578339; 62,1.445258141; 63,1.381029367; 64,1.308333635; 65,1.429936647; 66,1.324193954; 67,1.215524554; 68,1.132795691; 69,1.039966226; 70,0.957139969; 71,0.881121516; 72,0.764806509; 73,0.679720461; 74,1.153712869; 75,1.617045045; 76,1.342065096; 77,1.21108222; 78,1.097126365; 79,0.956687152; 80,0.846820831; 81,0.726776063; 82,0.637088716; 83,0.566960931; 84,0; 85,0.081746899; 86,0.287258357; 87,0.440648884; 88,0.623197138; 89,0.745818675; 90,0.877141893; 91,1.14376235; 92,1.091307402;
         93,1.166081309; 94,1.204966307; 95,1.155335188; 96,1.090149403; 97,1.023901701; 98,0.955312788; 99,0.895717919; 100,0.781589091; 101,0.711237729; 102,0.642216742; 103,0.592425168; 104,0.53075856; 105,0.470919639; 106,0.424907953; 107,0.379154414; 108,0.341206133; 109,0.313439339; 110,0.291419089; 111,0.282484144], extrapolation=Modelica.Blocks.Types.Extrapolation.HoldLastPoint)
                                                                      annotation (Placement(transformation(extent={{-80,-50},{-60,-30}})));
   Waterway.Pipe pipe3(H=0) annotation (Placement(transformation(extent={{-10,-50},{10,-30}})));
   Waterway.Reservoir tail3 annotation (Placement(transformation(extent={{60,-50},{40,-30}})));
-  Waterway.VolumeFlowSource volumeFlowFiltered(useInput=true, useFilter=true) annotation (Placement(transformation(extent={{-48,-50},{-28,-30}})));
+  Waterway.VolumeFlowSource volumeFlowFiltered(useInput=true, useFilter=true, fixElevation = true) annotation (Placement(transformation(extent={{-48,-50},{-28,-30}})));
 equation
   connect(pipe1.o, tail1.o) annotation (Line(points={{10,40},{40,40}}, color={0,128,255}));
   connect(volumeFlowConstant.o, pipe1.i) annotation (Line(points={{-30,40},{-10,40}}, color={0,128,255}));

--- a/OpenHPL/Examples/package.order
+++ b/OpenHPL/Examples/package.order
@@ -2,9 +2,9 @@ BranchingPipes
 SimpleValve
 SimpleValveWithCreek
 SimpleTurbine
+DetailedTurbine
 SimpleGen
 SimpleGenFrancis
-DetailedTurbine
 DetailedGen
 DetailedGenFrancis
 PowerSystemSimple

--- a/OpenHPL/Interfaces/Contact.mo
+++ b/OpenHPL/Interfaces/Contact.mo
@@ -4,9 +4,8 @@ connector Contact "Water flow connector"
   SI.Pressure p "Contact pressure";
   //SI.Temperature T "Contact temperature";
   flow SI.MassFlowRate mdot "Mass flow rate through the contact";
-  SI.Height z "Elevation at connection point";
-  flow Real gz(unit="m2/s") "Auxiliary elevation flow variable (always zero, for connector balance)";
- 
+  Elevation elevation "Overconstrained elevation at connection point";
+
   annotation (
     Documentation(info = "<html>
 <p>Contact is a basic water flow connector, which consists of water pressure, mass flow rate,
@@ -16,15 +15,17 @@ and elevation at the connector (positive if water is flowing into connector and 
 <ul>
 <li><code>p</code> &ndash; Pressure (potential variable, equated across connections)</li>
 <li><code>mdot</code> &ndash; Mass flow rate (flow variable, summed to zero across connections)</li>
-<li><code>z</code> &ndash; Elevation (potential variable, equated across connections).
+<li><code>elevation.z</code> &ndash; Elevation (overconstrained variable, propagated via spanning tree).
 Each component provides an equation relating its connector elevations,
 enabling automatic propagation of absolute elevation through the system.
-Source components (e.g., Reservoir) set the absolute reference elevation.</li>
+Source components (e.g., Reservoir) set the absolute reference elevation.
+Uses the overconstrained connector mechanism (Modelica Spec 9.4) to support
+arbitrary topologies including parallel pipes and loops.</li>
 </ul>
 </html>"),
   Icon(graphics = {
-    Text(origin = {0, -175}, 
-         textColor = {0, 85, 255}, 
-         extent = {{-100, 100}, {100, -100}}, 
-         textString = DynamicSelect("", if showElevation then String(z) else ""))}));
+    Text(origin = {0, -175},
+         textColor = {0, 85, 255},
+         extent = {{-100, 100}, {100, -100}},
+         textString = DynamicSelect("", if showElevation then String(elevation.z) else ""))}));
 end Contact;

--- a/OpenHPL/Interfaces/Contact.mo
+++ b/OpenHPL/Interfaces/Contact.mo
@@ -3,8 +3,20 @@ connector Contact "Water flow connector"
   SI.Pressure p "Contact pressure";
   //SI.Temperature T "Contact temperature";
   flow SI.MassFlowRate mdot "Mass flow rate through the contact";
+  SI.Height z "Elevation at connection point";
   annotation (
     Documentation(info = "<html>
-<p>Contact is a basic water flow connector, which consists of water pressure and mass flow rate through the connector (positive if water is flowing into connector and negative if flowing out).</p>
+<p>Contact is a basic water flow connector, which consists of water pressure, mass flow rate,
+and elevation at the connector (positive if water is flowing into connector and negative if flowing out).</p>
+
+<h5>Variables</h5>
+<ul>
+<li><code>p</code> &ndash; Pressure (potential variable, equated across connections)</li>
+<li><code>mdot</code> &ndash; Mass flow rate (flow variable, summed to zero across connections)</li>
+<li><code>z</code> &ndash; Elevation (potential variable, equated across connections).
+Each component provides an equation relating its connector elevations,
+enabling automatic propagation of absolute elevation through the system.
+Source components (e.g., Reservoir) set the absolute reference elevation.</li>
+</ul>
 </html>"));
 end Contact;

--- a/OpenHPL/Interfaces/Contact.mo
+++ b/OpenHPL/Interfaces/Contact.mo
@@ -4,6 +4,7 @@ connector Contact "Water flow connector"
   //SI.Temperature T "Contact temperature";
   flow SI.MassFlowRate mdot "Mass flow rate through the contact";
   SI.Height z "Elevation at connection point";
+  flow Real gz(unit="m2/s") "Auxiliary elevation flow variable (always zero, for connector balance)";
   annotation (
     Documentation(info = "<html>
 <p>Contact is a basic water flow connector, which consists of water pressure, mass flow rate,

--- a/OpenHPL/Interfaces/Contact.mo
+++ b/OpenHPL/Interfaces/Contact.mo
@@ -1,10 +1,12 @@
 within OpenHPL.Interfaces;
 connector Contact "Water flow connector"
+  parameter Boolean showElevation = true "Show elevation z";
   SI.Pressure p "Contact pressure";
   //SI.Temperature T "Contact temperature";
   flow SI.MassFlowRate mdot "Mass flow rate through the contact";
   SI.Height z "Elevation at connection point";
   flow Real gz(unit="m2/s") "Auxiliary elevation flow variable (always zero, for connector balance)";
+ 
   annotation (
     Documentation(info = "<html>
 <p>Contact is a basic water flow connector, which consists of water pressure, mass flow rate,
@@ -19,5 +21,10 @@ Each component provides an equation relating its connector elevations,
 enabling automatic propagation of absolute elevation through the system.
 Source components (e.g., Reservoir) set the absolute reference elevation.</li>
 </ul>
-</html>"));
+</html>"),
+  Icon(graphics = {
+    Text(origin = {0, -175}, 
+         textColor = {0, 85, 255}, 
+         extent = {{-100, 100}, {100, -100}}, 
+         textString = DynamicSelect("", if showElevation then String(z) else ""))}));
 end Contact;

--- a/OpenHPL/Interfaces/Elevation.mo
+++ b/OpenHPL/Interfaces/Elevation.mo
@@ -1,0 +1,10 @@
+within OpenHPL.Interfaces;
+record Elevation "Overconstrained elevation record for connector balance"
+  SI.Position z "Elevation at connection point";
+  function equalityConstraint
+    input Elevation e1;
+    input Elevation e2;
+    output Real residue[0] "No residual equations — elevation is propagated via spanning tree";
+  algorithm
+  end equalityConstraint;
+end Elevation;

--- a/OpenHPL/Interfaces/TurbineContacts.mo
+++ b/OpenHPL/Interfaces/TurbineContacts.mo
@@ -1,6 +1,5 @@
 within OpenHPL.Interfaces;
 partial model TurbineContacts "Model of turbine connectors"
-  extends Interfaces.TwoContacts;
   parameter Boolean enable_P_out = false "If checked, get a connector for the output power"
     annotation (choices(checkBox = true), Dialog(group="Outputs",tab="I/O"));
   input Modelica.Blocks.Interfaces.RealInput u_t "[Guide vane|nozzle] opening of the turbine(=1: completely open, =0: completely closed)"

--- a/OpenHPL/Interfaces/TwoContacts.mo
+++ b/OpenHPL/Interfaces/TwoContacts.mo
@@ -7,7 +7,7 @@ partial model TwoContacts "Model of two connectors"
                                annotation (
     Placement(transformation(extent={{90,-10},{110,10}})));
 equation
-  i.gz = 0 "Elevation auxiliary variable (no elevation source/sink at this connection point)";
+  o.gz = i.gz "Elevation auxiliary variable: propagate gz from inlet to outlet";
   annotation (
     Documentation(info = "<html>
     <p>TwoContact is a partial model, which consists of two Contacts <em>i</em>and <em>o</em>.

--- a/OpenHPL/Interfaces/TwoContacts.mo
+++ b/OpenHPL/Interfaces/TwoContacts.mo
@@ -8,7 +8,7 @@ partial model TwoContacts "Model of two connectors"
                                annotation (
     Placement(transformation(extent={{90,-10},{110,10}})));
 equation
-  o.gz = i.gz "Elevation auxiliary variable: propagate gz from inlet to outlet";
+  Connections.branch(i.elevation, o.elevation) "Elevation graph: inlet and outlet are in the same connected set";
   annotation (
     Documentation(info = "<html>
     <p>TwoContact is a partial model, which consists of two Contacts <em>i</em>and <em>o</em>.

--- a/OpenHPL/Interfaces/TwoContacts.mo
+++ b/OpenHPL/Interfaces/TwoContacts.mo
@@ -1,9 +1,10 @@
 within OpenHPL.Interfaces;
 partial model TwoContacts "Model of two connectors"
-  Contact_i i "Inlet contact (positive design flow direction is from i to o)"
+  outer Data data;
+  Contact_i i(showElevation=data.showElevation) "Inlet contact (positive design flow direction is from i to o)"
                               annotation (
     Placement(transformation(extent={{-110,-10},{-90,10}})));
-  Contact_o o "Outlet contact (positive design flow direction is from i to o)"
+  Contact_o o(showElevation=data.showElevation) "Outlet contact (positive design flow direction is from i to o)"
                                annotation (
     Placement(transformation(extent={{90,-10},{110,10}})));
 equation

--- a/OpenHPL/Interfaces/TwoContacts.mo
+++ b/OpenHPL/Interfaces/TwoContacts.mo
@@ -6,6 +6,8 @@ partial model TwoContacts "Model of two connectors"
   Contact_o o "Outlet contact (positive design flow direction is from i to o)"
                                annotation (
     Placement(transformation(extent={{90,-10},{110,10}})));
+equation
+  i.gz = 0 "Elevation auxiliary variable (no elevation source/sink at this connection point)";
   annotation (
     Documentation(info = "<html>
     <p>TwoContact is a partial model, which consists of two Contacts <em>i</em>and <em>o</em>.

--- a/OpenHPL/Interfaces/package.order
+++ b/OpenHPL/Interfaces/package.order
@@ -1,5 +1,6 @@
 Contact
 Contact_i
 Contact_o
+Elevation
 TurbineContacts
 TwoContacts

--- a/OpenHPL/Waterway/BendPipe.mo
+++ b/OpenHPL/Waterway/BendPipe.mo
@@ -16,8 +16,6 @@ model BendPipe "Bend in pipes"
   SI.Pressure dp "Pressure drop of fitting";
   SI.MassFlowRate mdot "Mass flow rate";
   extends OpenHPL.Interfaces.TwoContacts;
-initial equation
-  o.z = i.z "Elevation propagation: no height change across bend";
 equation
   v = mdot / data.rho / A;
   dp = K_L * 0.5 * data.rho * v^2;
@@ -25,6 +23,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot + o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
+  o.z = i.z "Elevation propagation: no height change across bend";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p>Usually minor head losses in pipes are considered to be due to fittings, diffusers, nozzles, bend in pipes, etc. We are more interested in head loss due to bend pipes for this model.</p>

--- a/OpenHPL/Waterway/BendPipe.mo
+++ b/OpenHPL/Waterway/BendPipe.mo
@@ -23,7 +23,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot + o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
-  o.z = i.z "Elevation propagation: no height change across bend";
+  o.elevation.z = i.elevation.z "Elevation propagation: no height change across bend";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p>Usually minor head losses in pipes are considered to be due to fittings, diffusers, nozzles, bend in pipes, etc. We are more interested in head loss due to bend pipes for this model.</p>

--- a/OpenHPL/Waterway/BendPipe.mo
+++ b/OpenHPL/Waterway/BendPipe.mo
@@ -23,6 +23,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot + o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
+  o.z = i.z "Elevation propagation: no height change across bend";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p>Usually minor head losses in pipes are considered to be due to fittings, diffusers, nozzles, bend in pipes, etc. We are more interested in head loss due to bend pipes for this model.</p>

--- a/OpenHPL/Waterway/BendPipe.mo
+++ b/OpenHPL/Waterway/BendPipe.mo
@@ -16,6 +16,8 @@ model BendPipe "Bend in pipes"
   SI.Pressure dp "Pressure drop of fitting";
   SI.MassFlowRate mdot "Mass flow rate";
   extends OpenHPL.Interfaces.TwoContacts;
+initial equation
+  o.z = i.z "Elevation propagation: no height change across bend";
 equation
   v = mdot / data.rho / A;
   dp = K_L * 0.5 * data.rho * v^2;
@@ -23,7 +25,6 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot + o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
-  o.z = i.z "Elevation propagation: no height change across bend";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p>Usually minor head losses in pipes are considered to be due to fittings, diffusers, nozzles, bend in pipes, etc. We are more interested in head loss due to bend pipes for this model.</p>

--- a/OpenHPL/Waterway/DraftTube.mo
+++ b/OpenHPL/Waterway/DraftTube.mo
@@ -153,7 +153,7 @@ equation
   p_o = o.p;
   i.mdot+o.mdot=0;
   mdot = i.mdot;
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
+  o.elevation.z = i.elevation.z - H "Elevation propagation: outlet is H below inlet";
   annotation (preferredView="info", Documentation(info="<html>
     <p>Two of the draft tubes are modeled using <em>Momentum balance</em>.
     They are:</p>

--- a/OpenHPL/Waterway/DraftTube.mo
+++ b/OpenHPL/Waterway/DraftTube.mo
@@ -91,6 +91,7 @@ initial equation
     Vdot = Vdot_0;
     //n.T = p.T;
   end if;
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 equation
   der(M) = Mdot + F "Momentum balance";
   if DraftTubeType == OpenHPL.Types.DraftTube.ConicalDiffuser then
@@ -153,7 +154,6 @@ equation
   p_o = o.p;
   i.mdot+o.mdot=0;
   mdot = i.mdot;
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
   annotation (preferredView="info", Documentation(info="<html>
     <p>Two of the draft tubes are modeled using <em>Momentum balance</em>.
     They are:</p>

--- a/OpenHPL/Waterway/DraftTube.mo
+++ b/OpenHPL/Waterway/DraftTube.mo
@@ -91,7 +91,6 @@ initial equation
     Vdot = Vdot_0;
     //n.T = p.T;
   end if;
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 equation
   der(M) = Mdot + F "Momentum balance";
   if DraftTubeType == OpenHPL.Types.DraftTube.ConicalDiffuser then
@@ -154,6 +153,7 @@ equation
   p_o = o.p;
   i.mdot+o.mdot=0;
   mdot = i.mdot;
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
   annotation (preferredView="info", Documentation(info="<html>
     <p>Two of the draft tubes are modeled using <em>Momentum balance</em>.
     They are:</p>

--- a/OpenHPL/Waterway/DraftTube.mo
+++ b/OpenHPL/Waterway/DraftTube.mo
@@ -153,6 +153,7 @@ equation
   p_o = o.p;
   i.mdot+o.mdot=0;
   mdot = i.mdot;
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
   annotation (preferredView="info", Documentation(info="<html>
     <p>Two of the draft tubes are modeled using <em>Momentum balance</em>.
     They are:</p>

--- a/OpenHPL/Waterway/Fitting.mo
+++ b/OpenHPL/Waterway/Fitting.mo
@@ -21,6 +21,8 @@ model Fitting "Different pipes fitting"
   Real phi "Dimensionless factor based on the type of fitting ";
   /* Connector */
   extends OpenHPL.Interfaces.TwoContacts;
+initial equation
+  o.z = i.z "Elevation propagation: no height change across fitting";
 equation
   v = mdot / data.rho / A;
   if v>=0 then
@@ -53,7 +55,6 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
-  o.z = i.z "Elevation propagation: no height change across fitting";
   annotation (preferredView="info",
     Documentation(info="<html>
     <p>Various possibilities of the fittings for the pipes with different diameters

--- a/OpenHPL/Waterway/Fitting.mo
+++ b/OpenHPL/Waterway/Fitting.mo
@@ -53,6 +53,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
+  o.z = i.z "Elevation propagation: no height change across fitting";
   annotation (preferredView="info",
     Documentation(info="<html>
     <p>Various possibilities of the fittings for the pipes with different diameters

--- a/OpenHPL/Waterway/Fitting.mo
+++ b/OpenHPL/Waterway/Fitting.mo
@@ -21,8 +21,6 @@ model Fitting "Different pipes fitting"
   Real phi "Dimensionless factor based on the type of fitting ";
   /* Connector */
   extends OpenHPL.Interfaces.TwoContacts;
-initial equation
-  o.z = i.z "Elevation propagation: no height change across fitting";
 equation
   v = mdot / data.rho / A;
   if v>=0 then
@@ -55,6 +53,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
+  o.z = i.z "Elevation propagation: no height change across fitting";
   annotation (preferredView="info",
     Documentation(info="<html>
     <p>Various possibilities of the fittings for the pipes with different diameters

--- a/OpenHPL/Waterway/Fitting.mo
+++ b/OpenHPL/Waterway/Fitting.mo
@@ -53,7 +53,7 @@ equation
   o.p = i.p - dp "Pressure of the output connector";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Flow direction";
-  o.z = i.z "Elevation propagation: no height change across fitting";
+  o.elevation.z = i.elevation.z "Elevation propagation: no height change across fitting";
   annotation (preferredView="info",
     Documentation(info="<html>
     <p>Various possibilities of the fittings for the pipes with different diameters

--- a/OpenHPL/Waterway/Gate.mo
+++ b/OpenHPL/Waterway/Gate.mo
@@ -25,8 +25,6 @@ model Gate "Model of a sluice or tainter gate based on [Bollrich2019]"
           extent={{-20,-20},{20,20}},
           rotation=270,
           origin={0,120})));
-initial equation
-  o.z = i.z "Elevation propagation: gate at same elevation";
 equation
   mu_A = psi/sqrt(1+psi*a/h_0);
   if sluice then
@@ -53,6 +51,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_0 * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_2 * data.g * data.rho + data.p_a "Outlet water pressure";
+  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate.mo
+++ b/OpenHPL/Waterway/Gate.mo
@@ -51,6 +51,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_0 * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_2 * data.g * data.rho + data.p_a "Outlet water pressure";
+  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate.mo
+++ b/OpenHPL/Waterway/Gate.mo
@@ -25,6 +25,8 @@ model Gate "Model of a sluice or tainter gate based on [Bollrich2019]"
           extent={{-20,-20},{20,20}},
           rotation=270,
           origin={0,120})));
+initial equation
+  o.z = i.z "Elevation propagation: gate at same elevation";
 equation
   mu_A = psi/sqrt(1+psi*a/h_0);
   if sluice then
@@ -51,7 +53,6 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_0 * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_2 * data.g * data.rho + data.p_a "Outlet water pressure";
-  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate.mo
+++ b/OpenHPL/Waterway/Gate.mo
@@ -51,7 +51,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_0 * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_2 * data.g * data.rho + data.p_a "Outlet water pressure";
-  o.z = i.z "Elevation propagation: gate at same elevation";
+  o.elevation.z = i.elevation.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate_HR.mo
+++ b/OpenHPL/Waterway/Gate_HR.mo
@@ -50,6 +50,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_i * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_o * data.g * data.rho + data.p_a "Outlet water pressure";
+  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate_HR.mo
+++ b/OpenHPL/Waterway/Gate_HR.mo
@@ -33,6 +33,8 @@ protected
   SI.VolumeFlowRate Vdot_full "Fully submerged base volume flow rate through the gate";
   Real Cdx "Discharge coefficient tuned for a smooth transition between partially and fully submerged";
 
+initial equation
+  o.z = i.z "Elevation propagation: gate at same elevation";
 equation
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
@@ -50,7 +52,6 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_i * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_o * data.g * data.rho + data.p_a "Outlet water pressure";
-  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate_HR.mo
+++ b/OpenHPL/Waterway/Gate_HR.mo
@@ -33,8 +33,6 @@ protected
   SI.VolumeFlowRate Vdot_full "Fully submerged base volume flow rate through the gate";
   Real Cdx "Discharge coefficient tuned for a smooth transition between partially and fully submerged";
 
-initial equation
-  o.z = i.z "Elevation propagation: gate at same elevation";
 equation
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
@@ -52,6 +50,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_i * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_o * data.g * data.rho + data.p_a "Outlet water pressure";
+  o.z = i.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Gate_HR.mo
+++ b/OpenHPL/Waterway/Gate_HR.mo
@@ -50,7 +50,7 @@ equation
   mdot = Vdot * data.rho "Mass flow rate through the gate";
   i.p = h_i * data.g * data.rho + data.p_a "Inlet water pressure";
   o.p = h_o * data.g * data.rho + data.p_a "Outlet water pressure";
-  o.z = i.z "Elevation propagation: gate at same elevation";
+  o.elevation.z = i.elevation.z "Elevation propagation: gate at same elevation";
   annotation (
     preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/OpenChannel.mo
+++ b/OpenHPL/Waterway/OpenChannel.mo
@@ -39,6 +39,7 @@ equation
 // presurre boundaries
   i.p = h[1] * data.g * data.rho + data.p_a;
   o.p = h[N] * data.g * data.rho + data.p_a;
+  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p style=\"color: #ff0000;\"><em>Note: Currently under investigation for plausibility.</em></p>

--- a/OpenHPL/Waterway/OpenChannel.mo
+++ b/OpenHPL/Waterway/OpenChannel.mo
@@ -30,6 +30,8 @@ model OpenChannel "Open channel model (use KP scheme)"
     boundaryValues=[h_0[1] + H[1],Vdot_i/W; h_0[N] + H[2],Vdot_o/W],
     boundaryCondition=BoundaryCondition,
     SteadyState=SteadyState) annotation (Placement(transformation(extent={{-10,-8},{10,12}})));
+initial equation
+  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
 equation
 // define a vector of the water depth in the channel
   h = openChannel.h;
@@ -39,7 +41,6 @@ equation
 // presurre boundaries
   i.p = h[1] * data.g * data.rho + data.p_a;
   o.p = h[N] * data.g * data.rho + data.p_a;
-  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p style=\"color: #ff0000;\"><em>Note: Currently under investigation for plausibility.</em></p>

--- a/OpenHPL/Waterway/OpenChannel.mo
+++ b/OpenHPL/Waterway/OpenChannel.mo
@@ -30,8 +30,6 @@ model OpenChannel "Open channel model (use KP scheme)"
     boundaryValues=[h_0[1] + H[1],Vdot_i/W; h_0[N] + H[2],Vdot_o/W],
     boundaryCondition=BoundaryCondition,
     SteadyState=SteadyState) annotation (Placement(transformation(extent={{-10,-8},{10,12}})));
-initial equation
-  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
 equation
 // define a vector of the water depth in the channel
   h = openChannel.h;
@@ -41,6 +39,7 @@ equation
 // presurre boundaries
   i.p = h[1] * data.g * data.rho + data.p_a;
   o.p = h[N] * data.g * data.rho + data.p_a;
+  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p style=\"color: #ff0000;\"><em>Note: Currently under investigation for plausibility.</em></p>

--- a/OpenHPL/Waterway/OpenChannel.mo
+++ b/OpenHPL/Waterway/OpenChannel.mo
@@ -39,7 +39,7 @@ equation
 // presurre boundaries
   i.p = h[1] * data.g * data.rho + data.p_a;
   o.p = h[N] * data.g * data.rho + data.p_a;
-  o.z = i.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
+  o.elevation.z = i.elevation.z - (H[1] - H[2]) "Elevation propagation: channel bed drops from H[1] to H[2]";
   annotation (preferredView="info",
     Documentation(info="<html>
 <p style=\"color: #ff0000;\"><em>Note: Currently under investigation for plausibility.</em></p>

--- a/OpenHPL/Waterway/Penstock.mo
+++ b/OpenHPL/Waterway/Penstock.mo
@@ -33,7 +33,6 @@ initial equation
   mdot_V = data.rho * Vdot_0;
   mdot = data.rho * Vdot_0 * ones(N - 2);
   p_ = p_i + dp:dp:p_i + dp * (N - 1);
-  o.z = i.z - H "Outlet elevation is H below inlet";
 equation
   // Pipe flow rate
   mdot_R = i.mdot;
@@ -84,6 +83,7 @@ equation
   // volumetric flow rates for all cells
   V_p_out = mdot ./ rho_m;
   V_p_out_end = mdot_V / (data.rho * (1 + data.beta * (p_o - data.p_a)));
+  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html><head></head><body><p>This is a more detaied model of the pipe that can be use for proper modeling of penstock. (This model does not work well. Instead PenstockKP model can be used.)</p><p>The model for the penstock with the elastic walls and compressible water with simple discretization method (Staggered grid). The geometry of the penstock is described due to figure:</p>
 <p><img src=\"modelica://OpenHPL/Resources/Images/pipe.svg\"></p>

--- a/OpenHPL/Waterway/Penstock.mo
+++ b/OpenHPL/Waterway/Penstock.mo
@@ -83,6 +83,7 @@ equation
   // volumetric flow rates for all cells
   V_p_out = mdot ./ rho_m;
   V_p_out_end = mdot_V / (data.rho * (1 + data.beta * (p_o - data.p_a)));
+  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html><head></head><body><p>This is a more detaied model of the pipe that can be use for proper modeling of penstock. (This model does not work well. Instead PenstockKP model can be used.)</p><p>The model for the penstock with the elastic walls and compressible water with simple discretization method (Staggered grid). The geometry of the penstock is described due to figure:</p>
 <p><img src=\"modelica://OpenHPL/Resources/Images/pipe.svg\"></p>

--- a/OpenHPL/Waterway/Penstock.mo
+++ b/OpenHPL/Waterway/Penstock.mo
@@ -83,7 +83,7 @@ equation
   // volumetric flow rates for all cells
   V_p_out = mdot ./ rho_m;
   V_p_out_end = mdot_V / (data.rho * (1 + data.beta * (p_o - data.p_a)));
-  o.z = i.z - H "Outlet elevation is H below inlet";
+  o.elevation.z = i.elevation.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html><head></head><body><p>This is a more detaied model of the pipe that can be use for proper modeling of penstock. (This model does not work well. Instead PenstockKP model can be used.)</p><p>The model for the penstock with the elastic walls and compressible water with simple discretization method (Staggered grid). The geometry of the penstock is described due to figure:</p>
 <p><img src=\"modelica://OpenHPL/Resources/Images/pipe.svg\"></p>

--- a/OpenHPL/Waterway/Penstock.mo
+++ b/OpenHPL/Waterway/Penstock.mo
@@ -33,6 +33,7 @@ initial equation
   mdot_V = data.rho * Vdot_0;
   mdot = data.rho * Vdot_0 * ones(N - 2);
   p_ = p_i + dp:dp:p_i + dp * (N - 1);
+  o.z = i.z - H "Outlet elevation is H below inlet";
 equation
   // Pipe flow rate
   mdot_R = i.mdot;
@@ -83,7 +84,6 @@ equation
   // volumetric flow rates for all cells
   V_p_out = mdot ./ rho_m;
   V_p_out_end = mdot_V / (data.rho * (1 + data.beta * (p_o - data.p_a)));
-  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html><head></head><body><p>This is a more detaied model of the pipe that can be use for proper modeling of penstock. (This model does not work well. Instead PenstockKP model can be used.)</p><p>The model for the penstock with the elastic walls and compressible water with simple discretization method (Staggered grid). The geometry of the penstock is described due to figure:</p>
 <p><img src=\"modelica://OpenHPL/Resources/Images/pipe.svg\"></p>

--- a/OpenHPL/Waterway/PenstockKP.mo
+++ b/OpenHPL/Waterway/PenstockKP.mo
@@ -115,6 +115,7 @@ equation
   S_[N + 1:2 * N] = F_ap * data.g * H / L - F_f / dx;
   // diff. equation
   der(U) = KP.diff_eq;
+  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Elastic Penstock with KP Method</h4>

--- a/OpenHPL/Waterway/PenstockKP.mo
+++ b/OpenHPL/Waterway/PenstockKP.mo
@@ -115,7 +115,7 @@ equation
   S_[N + 1:2 * N] = F_ap * data.g * H / L - F_f / dx;
   // diff. equation
   der(U) = KP.diff_eq;
-  o.z = i.z - H "Outlet elevation is H below inlet";
+  o.elevation.z = i.elevation.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Elastic Penstock with KP Method</h4>

--- a/OpenHPL/Waterway/PenstockKP.mo
+++ b/OpenHPL/Waterway/PenstockKP.mo
@@ -54,6 +54,7 @@ initial equation
     mdot[2:N - 1] = data.rho * Vdot_0[2:N - 1];
     p_p = p_p0;
   end if;
+  o.z = i.z - H "Outlet elevation is H below inlet";
 equation
   // Pipe flow rate
   mdot_R = i.mdot;
@@ -115,7 +116,6 @@ equation
   S_[N + 1:2 * N] = F_ap * data.g * H / L - F_f / dx;
   // diff. equation
   der(U) = KP.diff_eq;
-  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Elastic Penstock with KP Method</h4>

--- a/OpenHPL/Waterway/PenstockKP.mo
+++ b/OpenHPL/Waterway/PenstockKP.mo
@@ -54,7 +54,6 @@ initial equation
     mdot[2:N - 1] = data.rho * Vdot_0[2:N - 1];
     p_p = p_p0;
   end if;
-  o.z = i.z - H "Outlet elevation is H below inlet";
 equation
   // Pipe flow rate
   mdot_R = i.mdot;
@@ -116,6 +115,7 @@ equation
   S_[N + 1:2 * N] = F_ap * data.g * H / L - F_f / dx;
   // diff. equation
   der(U) = KP.diff_eq;
+  o.z = i.z - H "Outlet elevation is H below inlet";
   annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Elastic Penstock with KP Method</h4>

--- a/OpenHPL/Waterway/Pipe.mo
+++ b/OpenHPL/Waterway/Pipe.mo
@@ -61,7 +61,6 @@ initial equation
   else
     Vdot=Vdot_0;
   end if;
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 algorithm
     assert( phi < 1.0,  "Change in pipe diameter is too large. (angle= "+String(phi)+" )",AssertionLevel.warning);
 equation
@@ -74,6 +73,7 @@ equation
   p_o = o.p "Outlet pressure";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 
   annotation (preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Pipe.mo
+++ b/OpenHPL/Waterway/Pipe.mo
@@ -73,7 +73,7 @@ equation
   p_o = o.p "Outlet pressure";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
+  o.elevation.z = i.elevation.z - H "Elevation propagation: outlet is H below inlet";
 
   annotation (preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Pipe.mo
+++ b/OpenHPL/Waterway/Pipe.mo
@@ -61,6 +61,7 @@ initial equation
   else
     Vdot=Vdot_0;
   end if;
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 algorithm
     assert( phi < 1.0,  "Change in pipe diameter is too large. (angle= "+String(phi)+" )",AssertionLevel.warning);
 equation
@@ -73,7 +74,6 @@ equation
   p_o = o.p "Outlet pressure";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
-  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 
   annotation (preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Pipe.mo
+++ b/OpenHPL/Waterway/Pipe.mo
@@ -73,6 +73,7 @@ equation
   p_o = o.p "Outlet pressure";
   i.mdot+o.mdot = 0 "Mass balance";
   mdot = i.mdot "Inlet direction for mdot";
+  o.z = i.z - H "Elevation propagation: outlet is H below inlet";
 
   annotation (preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -6,6 +6,8 @@ model Reservoir "Model of the reservoir"
     annotation (Dialog(group="Setup", enable=not useLevel));
   parameter SI.Height z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
     annotation (Dialog(group="Geometry"));
+  parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
+    annotation (Dialog(group="Geometry"), choices(checkBox=true));
   parameter Boolean constantLevel=false "If checked, the reservoir keeps the constant water level h_0"
     annotation (
     Dialog(group="Setup", enable=not (useInflow or useLevel)),
@@ -52,6 +54,9 @@ initial equation
    if not useLevel then
     h = h_0;
    end if;
+  if fixElevation then
+    o.z = z_0;
+  end if;
 equation
   A =h * (W +h * Modelica.Math.tan(alpha))
     "Vertical cross section of the reservoir";
@@ -79,7 +84,6 @@ equation
   end if;
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
-  o.z = z_0 "Set absolute elevation at outlet";
   o.gz = 0 "Elevation auxiliary variable";
   //o.T = T_0 "TBD: Output temperature connector";
   annotation (preferredView="info", Documentation(info="<html>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -80,6 +80,7 @@ equation
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
   o.z = z_0 "Set absolute elevation at outlet";
+  o.gz = 0 "Elevation auxiliary variable";
   //o.T = T_0 "TBD: Output temperature connector";
   annotation (preferredView="info", Documentation(info="<html>
 <h4>Reservoir Model</h4>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -45,7 +45,7 @@ model Reservoir "Model of the reservoir"
   SI.Height h_abs = h + o.z "Absolute water level";
   SI.Pressure p_o "Outlet pressure";
 
-  OpenHPL.Interfaces.Contact_o o(p=p_o) "Outflow from reservoir" annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
+  OpenHPL.Interfaces.Contact_o o(p = p_o, showElevation = data.showElevation) "Outflow from reservoir" annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealInput inflow=Vdot_i if useInflow "Conditional input inflow of the reservoir" annotation (Placement(transformation(
         origin={-120,0},
         extent={{-20,-20},{20,20}})));

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -84,7 +84,9 @@ equation
   end if;
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
-  o.gz = 0 "Elevation auxiliary variable";
+  if fixElevation then
+    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+  end if;
   //o.T = T_0 "TBD: Output temperature connector";
   annotation (preferredView="info", Documentation(info="<html>
 <h4>Reservoir Model</h4>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -54,9 +54,6 @@ initial equation
    if not useLevel then
     h = h_0;
    end if;
-  if fixElevation then
-    o.z = z_0;
-  end if;
 equation
   A =h * (W +h * Modelica.Math.tan(alpha))
     "Vertical cross section of the reservoir";
@@ -85,6 +82,7 @@ equation
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
   if fixElevation then
+    o.z = z_0 "Set absolute elevation at outlet";
     o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
   end if;
   //o.T = T_0 "TBD: Output temperature connector";

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -6,7 +6,7 @@ model Reservoir "Model of the reservoir"
     annotation (Dialog(group="Setup", enable=not useLevel));
   parameter Boolean fixElevation=false "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
     annotation (Dialog(group="Geometry"), choices(checkBox=true));
-  parameter SI.Height z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
+  parameter SI.Position z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
     annotation (Dialog(group="Geometry", enable=fixElevation));
   parameter Boolean constantLevel=false "If checked, the reservoir keeps the constant water level h_0"
     annotation (
@@ -42,7 +42,7 @@ model Reservoir "Model of the reservoir"
   SI.Momentum M "Water momentum";
   SI.Force F_f "Friction force";
   SI.Height h "Water level";
-  SI.Height h_abs = h + o.z "Absolute water level";
+  SI.Height h_abs = h + o.elevation.z "Absolute water level";
   SI.Pressure p_o "Outlet pressure";
 
   OpenHPL.Interfaces.Contact_o o(p = p_o, showElevation = data.showElevation) "Outflow from reservoir" annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));
@@ -83,8 +83,13 @@ equation
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
   if fixElevation then
-    o.z = z_0 "Set absolute elevation at outlet";
-    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+    Connections.root(o.elevation) "This reservoir is the definite elevation reference root";
+    o.elevation.z = z_0 "Set absolute elevation at outlet";
+  else
+    Connections.potentialRoot(o.elevation) "May become root if no other component defines the elevation";
+    if Connections.isRoot(o.elevation) then
+      o.elevation.z = 0 "Default elevation when this reservoir is automatically selected as root";
+    end if;
   end if;
   //o.T = T_0 "TBD: Output temperature connector";
   annotation (preferredView="info", Documentation(info="<html>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -4,6 +4,8 @@ model Reservoir "Model of the reservoir"
   extends OpenHPL.Icons.Reservoir;
   parameter SI.Height h_0=50 "Initial water level above intake"
     annotation (Dialog(group="Setup", enable=not useLevel));
+  parameter SI.Height z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
+    annotation (Dialog(group="Geometry"));
   parameter Boolean constantLevel=false "If checked, the reservoir keeps the constant water level h_0"
     annotation (
     Dialog(group="Setup", enable=not (useInflow or useLevel)),
@@ -77,6 +79,7 @@ equation
   end if;
 
    o.mdot = -data.rho * Vdot_o "Output flow connector";
+  o.z = z_0 "Set absolute elevation at outlet";
   //o.T = T_0 "TBD: Output temperature connector";
   annotation (preferredView="info", Documentation(info="<html>
 <h4>Reservoir Model</h4>

--- a/OpenHPL/Waterway/Reservoir.mo
+++ b/OpenHPL/Waterway/Reservoir.mo
@@ -4,10 +4,10 @@ model Reservoir "Model of the reservoir"
   extends OpenHPL.Icons.Reservoir;
   parameter SI.Height h_0=50 "Initial water level above intake"
     annotation (Dialog(group="Setup", enable=not useLevel));
-  parameter SI.Height z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
-    annotation (Dialog(group="Geometry"));
-  parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
+  parameter Boolean fixElevation=false "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
     annotation (Dialog(group="Geometry"), choices(checkBox=true));
+  parameter SI.Height z_0=0 "Elevation of the reservoir outlet (sets absolute reference)"
+    annotation (Dialog(group="Geometry", enable=fixElevation));
   parameter Boolean constantLevel=false "If checked, the reservoir keeps the constant water level h_0"
     annotation (
     Dialog(group="Setup", enable=not (useInflow or useLevel)),
@@ -42,6 +42,7 @@ model Reservoir "Model of the reservoir"
   SI.Momentum M "Water momentum";
   SI.Force F_f "Friction force";
   SI.Height h "Water level";
+  SI.Height h_abs = h + o.z "Absolute water level";
   SI.Pressure p_o "Outlet pressure";
 
   OpenHPL.Interfaces.Contact_o o(p=p_o) "Outflow from reservoir" annotation (Placement(transformation(extent={{90,-10},{110,10}}), iconTransformation(extent={{90,-10},{110,10}})));

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -38,7 +38,9 @@ equation
   // boundaries
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
-  o.gz = 0 "Elevation auxiliary variable";
+  if fixElevation then
+    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+  end if;
   annotation (
     Documentation(preferredView="info", info="<html>
 <h4>Reservoir Channel Model</h4>

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -13,6 +13,8 @@ model ReservoirChannel "Reservoir model based on open channel model"
   parameter SI.Height h_0=50 "Initial water level of the reservoir";
   parameter SI.Height z_0=0 "Elevation of the reservoir outlet"
     annotation (Dialog(group="Geometry"));
+  parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
+    annotation (Dialog(group="Geometry"), choices(checkBox=true));
   // condition of steady state
   parameter Boolean SteadyState=data.SteadyState "If true, starts in steady state";
   // variables
@@ -28,11 +30,14 @@ model ReservoirChannel "Reservoir model based on open channel model"
     boundaryValues=[h_0 + H[1],q; h_0 + H[2],q],
     boundaryCondition=[true,true; false,true],
     SteadyState=SteadyState) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
+initial equation
+  if fixElevation then
+    o.z = z_0;
+  end if;
 equation
   // boundaries
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
-  o.z = z_0 "Set absolute elevation at outlet";
   o.gz = 0 "Elevation auxiliary variable";
   annotation (
     Documentation(preferredView="info", info="<html>

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -30,15 +30,12 @@ model ReservoirChannel "Reservoir model based on open channel model"
     boundaryValues=[h_0 + H[1],q; h_0 + H[2],q],
     boundaryCondition=[true,true; false,true],
     SteadyState=SteadyState) annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
-initial equation
-  if fixElevation then
-    o.z = z_0;
-  end if;
 equation
   // boundaries
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
   if fixElevation then
+    o.z = z_0 "Set absolute elevation at outlet";
     o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
   end if;
   annotation (

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -33,6 +33,7 @@ equation
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
   o.z = z_0 "Set absolute elevation at outlet";
+  o.gz = 0 "Elevation auxiliary variable";
   annotation (
     Documentation(preferredView="info", info="<html>
 <h4>Reservoir Channel Model</h4>

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -11,6 +11,8 @@ model ReservoirChannel "Reservoir model based on open channel model"
   parameter SI.Height H[2] = {2, 2} "Reservoir bed height from left and right side";
   // initialization
   parameter SI.Height h_0=50 "Initial water level of the reservoir";
+  parameter SI.Height z_0=0 "Elevation of the reservoir outlet"
+    annotation (Dialog(group="Geometry"));
   // condition of steady state
   parameter Boolean SteadyState=data.SteadyState "If true, starts in steady state";
   // variables
@@ -30,6 +32,7 @@ equation
   // boundaries
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
+  o.z = z_0 "Set absolute elevation at outlet";
   annotation (
     Documentation(preferredView="info", info="<html>
 <h4>Reservoir Channel Model</h4>

--- a/OpenHPL/Waterway/ReservoirChannel.mo
+++ b/OpenHPL/Waterway/ReservoirChannel.mo
@@ -11,7 +11,7 @@ model ReservoirChannel "Reservoir model based on open channel model"
   parameter SI.Height H[2] = {2, 2} "Reservoir bed height from left and right side";
   // initialization
   parameter SI.Height h_0=50 "Initial water level of the reservoir";
-  parameter SI.Height z_0=0 "Elevation of the reservoir outlet"
+  parameter SI.Position z_0=0 "Elevation of the reservoir outlet"
     annotation (Dialog(group="Geometry"));
   parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
     annotation (Dialog(group="Geometry"), choices(checkBox=true));
@@ -35,8 +35,13 @@ equation
   o.mdot =-q*W*data.rho;
   o.p = data.p_a + data.rho * data.g * openChannel.h[N];
   if fixElevation then
-    o.z = z_0 "Set absolute elevation at outlet";
-    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+    Connections.root(o.elevation) "This reservoir is the elevation reference root";
+    o.elevation.z = z_0 "Set absolute elevation at outlet";
+  else
+    Connections.potentialRoot(o.elevation) "May become root if no other root exists";
+    if Connections.isRoot(o.elevation) then
+      o.elevation.z = 0 "Default elevation if this becomes root";
+    end if;
   end if;
   annotation (
     Documentation(preferredView="info", info="<html>

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -30,7 +30,7 @@ model SurgeTank "Model of the surge tank/shaft"
   parameter Boolean SteadyState=data.SteadyState "If true, starts in steady state" annotation (Dialog(group="Initialization"));
   parameter SI.VolumeFlowRate Vdot_0 = 0 "Initial volume flow rate in the surge tank" annotation (
     Dialog(group = "Initialization"));
-  parameter SI.Height h_0 = 50 "Initial water level in the surge tank" annotation (
+  parameter SI.Height h_0 = 50 "Initial water level in the surge tank above inlet" annotation (
     Dialog(group = "Initialization"));
   parameter SI.Pressure p_ac = 4*data.p_a "Initial pressure of air-cushion inside the surge tank" annotation (
     Dialog(group = "Initialization",enable=SurgeTankType == OpenHPL.Types.SurgeTank.STAirCushion));
@@ -55,6 +55,7 @@ model SurgeTank "Model of the surge tank/shaft"
   SI.Pressure p_b "Pressure at bottom of the surge tank";
   Real phiSO "Dimensionless factor based on the type of fitting ";
   SI.Height h(start = h_0) "Water height in the surge tank";
+  SI.Height h_abs = h + o.z "Absolute water level";
   SI.VolumeFlowRate Vdot(start = Vdot_0, fixed=true) "Volume flow rate";
 
   Interfaces.Contact_i creek(

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -4,20 +4,18 @@ model SurgeTank "Model of the surge tank/shaft"
   extends OpenHPL.Icons.Surge(lds=l, Lds=L);
   extends OpenHPL.Interfaces.TwoContacts;
 
-  parameter Boolean useCreekIntake=false   "If checked, includes a creek intake connector" annotation (
-    Dialog(group = "Creek intake"),
-    choices(checkBox = true));
-  parameter SI.Height H_creek=H   "Height of the creek intake above the surge tank base" annotation (
-    Dialog(group = "Creek intake", enable = useCreekIntake));
+  parameter Types.SurgeTank SurgeTankType = OpenHPL.Types.SurgeTank.STSimple "Types of surge tank"
+    annotation (Dialog(group = "Surge tank types"));
+  parameter SI.Height H = 100 "Vertical component of the length of the surge shaft"
+    annotation (Dialog(group = "Geometry"));
+  parameter SI.Length L = H "Length of the surge shaft"
+    annotation (Dialog(group = "Geometry"));
+  parameter SI.Diameter D = 3 "Diameter of the surge shaft"
+    annotation (Dialog(group = "Geometry"));
+  parameter SI.Position H_creek=H   "Position of the creek intake above the surge tank base"
+    annotation (Dialog(group = "Geometry"));
 
-  parameter Types.SurgeTank SurgeTankType = OpenHPL.Types.SurgeTank.STSimple "Types of surge tank" annotation (
-    Dialog(group = "Surge tank types"));
-  parameter SI.Height H = 100 "Vertical component of the length of the surge shaft" annotation (
-    Dialog(group = "Geometry"));
-  parameter SI.Length L = H "Length of the surge shaft" annotation (
-    Dialog(group = "Geometry"));
-  parameter SI.Diameter D = 3 "Diameter of the surge shaft" annotation (
-    Dialog(group = "Geometry"));
+
   parameter SI.Height p_eps = data.p_eps "Pipe roughness height" annotation (
     Dialog(group = "Geometry"));
   parameter SI.Diameter D_so = D "If Sharp orifice type: Diameter of sharp orifice" annotation (
@@ -55,12 +53,12 @@ model SurgeTank "Model of the surge tank/shaft"
   SI.Pressure p_b "Pressure at bottom of the surge tank";
   Real phiSO "Dimensionless factor based on the type of fitting ";
   SI.Height h(start = h_0) "Water height in the surge tank";
-  SI.Height h_abs = h + o.elevation.z "Absolute water level";
+  SI.Position h_abs = h + o.elevation.z "Absolute water level";
   SI.VolumeFlowRate Vdot(start = Vdot_0, fixed=true) "Volume flow rate";
 
   Interfaces.Contact_i creek(
     p = p_t + data.rho * data.g * (h - H_creek),
-    mdot = mdot_creek) if useCreekIntake "Creek intake connector (connects to VolumeFlowSource)"
+    mdot = mdot_creek) "Creek intake connector (connects to VolumeFlowSource)"
     annotation (Placement(transformation(extent = {{-10, 90}, {10, 110}})));
 
 protected
@@ -88,10 +86,6 @@ equation
   der(M) = Mdot+F "Momentum balance";
   mdot = data.rho * Vdot;
   mdot = i.mdot + o.mdot "Mass balance";
-
-  if not useCreekIntake then
-    mdot_creek = 0;
-  end if "Conditional creek intake equation balance";
 
   der(m) = mdot + mdot_creek "Mass balance";
 
@@ -149,8 +143,10 @@ equation
     end if;
     p_t = data.p_a;
   end if;
+  Connections.branch(creek.elevation, o.elevation);
+  creek.elevation.z = o.elevation.z + H_creek "Creek elevation relative to surge tank base";
   o.elevation.z = i.elevation.z "Elevation at surge tank inlet and outlet are equal";
- annotation (preferredView="info",
+  annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Surge Tank Model</h4>
 
@@ -201,14 +197,20 @@ The manifold pressure is equal for all three connections. This is implemented vi
 
 <h5>Creek Intake</h5>
 
-<p>When <code>useCreekIntake = true</code>, an additional inlet connector <code>creek</code> becomes active.
-This connector can be attached to a <code>VolumeFlowSource</code> to model lateral inflow
-(e.g., a creek or groundwater seepage) entering the surge tank. The parameter <code>H_creek</code>
-specifies the height of the intake above the surge tank base (default H = at the top of the surge tank,
-not relavant if a volume flow source is connected).
-The connector pressure is set hydrostatically from the water surface down to the intake elevation,
+<p>The surge tank has a <code>creek</code> inlet connector that can be attached to a
+<code>VolumeFlowSource</code> to model lateral inflow (e.g., a creek or groundwater seepage)
+entering the surge tank. The connector is always present; when left unconnected,
+the flow is zero by Modelica's default flow-variable semantics and has no effect on
+the model. The parameter <code>H_creek</code> specifies the height of the intake above
+the surge tank base (default: equal to H). The boolean <code>useCreekIntake</code> controls
+the visibility of <code>H_creek</code> in the parameter dialog.</p>
+<p>The connector pressure is set hydrostatically from the water surface down to the intake elevation,
 so it correctly follows the actual water level <code>h</code> in the tank:</p>
 <p>$$ p_\\mathrm{creek} = p_\\mathrm{t} + \\rho g (h - H_\\mathrm{creek}) $$</p>
+<p>The creek connector participates in the overconstrained elevation graph via
+<code>Connections.branch(creek.elevation, o.elevation)</code>, ensuring that its elevation
+is consistent with the rest of the waterway:
+$$ z_\\mathrm{creek} = z_\\mathrm{o} + H_\\mathrm{creek} $$</p>
 <p>The creek inflow is included in the mass balance:</p>
 <p>$$ \\frac{\\mathrm{d}m}{\\mathrm{d}t} = \\rho \\dot{V} + \\dot{m}_\\mathrm{creek} $$</p>
 

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -148,13 +148,6 @@ equation
     end if;
     p_t = data.p_a;
   end if;
-  mdot = data.rho * Vdot;
-  Mdot = mdot * v;
-  F = F_p - F_f - F_g;
-  p_b = i.p "Linking bottom node pressure to connector";
-  i.p = o.p "Inlet and outlet pressure equality";
-  mdot = i.mdot+o.mdot "Mass balance";
-  F_g = m * data.g * cos_theta;
   o.z = i.z "Elevation at surge tank inlet and outlet are equal";
  annotation (preferredView="info",
     Documentation(info="<html>

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -72,7 +72,6 @@ initial equation
   else
     h = h_0;
   end if;
-  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
 
 equation
   assert( h >= 0, "Water level h in surge tank must be greater than 0!",
@@ -156,6 +155,7 @@ equation
   i.p = o.p "Inlet and outlet pressure equality";
   mdot = i.mdot+o.mdot "Mass balance";
   F_g = m * data.g * cos_theta;
+  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
  annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Surge Tank Model</h4>

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -55,7 +55,7 @@ model SurgeTank "Model of the surge tank/shaft"
   SI.Pressure p_b "Pressure at bottom of the surge tank";
   Real phiSO "Dimensionless factor based on the type of fitting ";
   SI.Height h(start = h_0) "Water height in the surge tank";
-  SI.Height h_abs = h + o.z "Absolute water level";
+  SI.Height h_abs = h + o.elevation.z "Absolute water level";
   SI.VolumeFlowRate Vdot(start = Vdot_0, fixed=true) "Volume flow rate";
 
   Interfaces.Contact_i creek(
@@ -149,7 +149,7 @@ equation
     end if;
     p_t = data.p_a;
   end if;
-  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
+  o.elevation.z = i.elevation.z "Elevation at surge tank inlet and outlet are equal";
  annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Surge Tank Model</h4>

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -148,7 +148,14 @@ equation
     end if;
     p_t = data.p_a;
   end if;
-
+  mdot = data.rho * Vdot;
+  Mdot = mdot * v;
+  F = F_p - F_f - F_g;
+  p_b = i.p "Linking bottom node pressure to connector";
+  i.p = o.p "Inlet and outlet pressure equality";
+  mdot = i.mdot+o.mdot "Mass balance";
+  F_g = m * data.g * cos_theta;
+  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
  annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Surge Tank Model</h4>

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -59,7 +59,8 @@ model SurgeTank "Model of the surge tank/shaft"
 
   Interfaces.Contact_i creek(
     p = p_t + data.rho * data.g * (h - H_creek),
-    mdot = mdot_creek) if useCreekIntake "Creek intake connector (connects to VolumeFlowSource)"
+    mdot = mdot_creek,
+    gz = 0) if useCreekIntake "Creek intake connector (connects to VolumeFlowSource)"
     annotation (Placement(transformation(extent = {{-10, 90}, {10, 110}})));
 
 protected

--- a/OpenHPL/Waterway/SurgeTank.mo
+++ b/OpenHPL/Waterway/SurgeTank.mo
@@ -59,8 +59,7 @@ model SurgeTank "Model of the surge tank/shaft"
 
   Interfaces.Contact_i creek(
     p = p_t + data.rho * data.g * (h - H_creek),
-    mdot = mdot_creek,
-    gz = 0) if useCreekIntake "Creek intake connector (connects to VolumeFlowSource)"
+    mdot = mdot_creek) if useCreekIntake "Creek intake connector (connects to VolumeFlowSource)"
     annotation (Placement(transformation(extent = {{-10, 90}, {10, 110}})));
 
 protected
@@ -73,6 +72,7 @@ initial equation
   else
     h = h_0;
   end if;
+  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
 
 equation
   assert( h >= 0, "Water level h in surge tank must be greater than 0!",
@@ -156,7 +156,6 @@ equation
   i.p = o.p "Inlet and outlet pressure equality";
   mdot = i.mdot+o.mdot "Mass balance";
   F_g = m * data.g * cos_theta;
-  o.z = i.z "Elevation at surge tank inlet and outlet are equal";
  annotation (preferredView="info",
     Documentation(info="<html>
 <h4>Surge Tank Model</h4>

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -39,6 +39,7 @@ equation
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
   o.z = z_0 "Set absolute elevation at outlet";
+  o.gz = 0 "Elevation auxiliary variable";
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));
   connect(firstOrder.u, outFlow) annotation (Line(
       points={{-62,-20},{-80,-20},{-80,0},{-120,0}},

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -11,11 +11,10 @@ model VolumeFlowSource "Volume flow source (either fixed or variable)"
     annotation (choices(checkBox = true),Dialog(enable=useInput));
   parameter SI.Time T_f=0.01 "Time constant of the first order filter."
     annotation (Dialog(enable=useInput and useFilter));
-  parameter SI.Height z_0=0 "Elevation of the outlet connection"
-    annotation (Dialog(group="Geometry"));
-  parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
+  parameter Boolean fixElevation=false "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
     annotation (Dialog(group="Geometry"), choices(checkBox=true));
-
+  parameter SI.Height z_0=0 "Elevation of the outlet connection"
+    annotation (Dialog(group="Geometry", enable=fixElevation));
   Interfaces.Contact_o o "Outlet flow connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealInput outFlow if useInput "Conditional input for defining the outlet flow [m3/s]"

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -11,6 +11,8 @@ model VolumeFlowSource "Volume flow source (either fixed or variable)"
     annotation (choices(checkBox = true),Dialog(enable=useInput));
   parameter SI.Time T_f=0.01 "Time constant of the first order filter."
     annotation (Dialog(enable=useInput and useFilter));
+  parameter SI.Height z_0=0 "Elevation of the outlet connection"
+    annotation (Dialog(group="Geometry"));
 
   Interfaces.Contact_o o "Outlet flow connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
@@ -36,6 +38,7 @@ equation
       color={0,0,127},
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
+  o.z = z_0 "Set absolute elevation at outlet";
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));
   connect(firstOrder.u, outFlow) annotation (Line(
       points={{-62,-20},{-80,-20},{-80,0},{-120,0}},

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -13,9 +13,9 @@ model VolumeFlowSource "Volume flow source (either fixed or variable)"
     annotation (Dialog(enable=useInput and useFilter));
   parameter Boolean fixElevation=false "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
     annotation (Dialog(group="Geometry"), choices(checkBox=true));
-  parameter SI.Height z_0=0 "Elevation of the outlet connection"
+  parameter SI.Position z_0=0 "Elevation of the outlet connection"
     annotation (Dialog(group="Geometry", enable=fixElevation));
-  Interfaces.Contact_o o "Outlet flow connector"
+  Interfaces.Contact_o o(showElevation = data.showElevation)  "Outlet flow connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
   Modelica.Blocks.Interfaces.RealInput outFlow if useInput "Conditional input for defining the outlet flow [m3/s]"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));
@@ -40,8 +40,13 @@ equation
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
   if fixElevation then
-    o.z = z_0 "Set absolute elevation at outlet";
-    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+    Connections.root(o.elevation) "This source is the elevation reference root";
+    o.elevation.z = z_0 "Set absolute elevation at outlet";
+  else
+    Connections.potentialRoot(o.elevation) "May become root if no other root exists";
+    if Connections.isRoot(o.elevation) then
+      o.elevation.z = 0 "Default elevation if this becomes root";
+    end if;
   end if;
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));
   connect(firstOrder.u, outFlow) annotation (Line(

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -13,6 +13,8 @@ model VolumeFlowSource "Volume flow source (either fixed or variable)"
     annotation (Dialog(enable=useInput and useFilter));
   parameter SI.Height z_0=0 "Elevation of the outlet connection"
     annotation (Dialog(group="Geometry"));
+  parameter Boolean fixElevation=true "If true (fixed), z_0 is enforced as initial value; if false (derived), elevation is determined by connected topology"
+    annotation (Dialog(group="Geometry"), choices(checkBox=true));
 
   Interfaces.Contact_o o "Outlet flow connector"
     annotation (Placement(transformation(extent={{90,-10},{110,10}})));
@@ -32,13 +34,16 @@ protected
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Blocks.Interfaces.RealOutput filtered if useFilter "filtered input"
     annotation (Placement(transformation(extent={{0,-30},{20,-10}})));
+initial equation
+  if fixElevation then
+    o.z = z_0;
+  end if;
 equation
   connect(filtered, Vdot) annotation (Line(
       points={{10,-20},{40,-20},{40,0},{80,0}},
       color={0,0,127},
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
-  o.z = z_0 "Set absolute elevation at outlet";
   o.gz = 0 "Elevation auxiliary variable";
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));
   connect(firstOrder.u, outFlow) annotation (Line(

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -44,7 +44,9 @@ equation
       color={0,0,127},
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
-  o.gz = 0 "Elevation auxiliary variable";
+  if fixElevation then
+    o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
+  end if;
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));
   connect(firstOrder.u, outFlow) annotation (Line(
       points={{-62,-20},{-80,-20},{-80,0},{-120,0}},

--- a/OpenHPL/Waterway/VolumeFlowSource.mo
+++ b/OpenHPL/Waterway/VolumeFlowSource.mo
@@ -34,10 +34,6 @@ protected
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
   Modelica.Blocks.Interfaces.RealOutput filtered if useFilter "filtered input"
     annotation (Placement(transformation(extent={{0,-30},{20,-10}})));
-initial equation
-  if fixElevation then
-    o.z = z_0;
-  end if;
 equation
   connect(filtered, Vdot) annotation (Line(
       points={{10,-20},{40,-20},{40,0},{80,0}},
@@ -45,6 +41,7 @@ equation
       pattern=LinePattern.Dot));
   o.mdot = -data.rho*Vdot;
   if fixElevation then
+    o.z = z_0 "Set absolute elevation at outlet";
     o.gz = 0 "Elevation reference: this component is the root of the connected elevation set";
   end if;
   connect(constantVolumeFlow.y, Vdot) annotation (Line(points={{-39,40},{40,40},{40,0},{80,0}}, color={0,0,127}));


### PR DESCRIPTION
Introduces elevation handling and propagation mechanism across the OpenHPL library.

ref: #45 

Key changes include:
-   **Elevation Mechanism**:  is supported by a new `Elevation` record which uses an overconstrained `equalityConstraint` for more reliable elevation propagation throughout the system.
-   **Centralized Display Control**: Adds a `showElevation` parameter to the `Data` record, enabling global control over the display of elevation on connectors in the icon layer.
