### PR TITLE
refactor!: Rename pipe `vertical` parameter to `slanted`

### DIFF
--- a/OpenHPL/Examples/SimpleGenFrancis.mo
+++ b/OpenHPL/Examples/SimpleGenFrancis.mo
@@ -16,7 +16,7 @@ model SimpleGenFrancis "Model of a hydropower system with Francis turbine model"
   ElectroMech.Generators.SynchGen generator(P_op=100e6, UseFrequencyOutput=false) annotation (Placement(transformation(extent={{40,-40},{20,-20}})));
   replaceable
   Waterway.Pipe penstock(
-    vertical=true,
+    slanted=true,
     L=600,
     H=428.5,
     D_i=3,

--- a/OpenHPL/Examples/SimpleTurbine.mo
+++ b/OpenHPL/Examples/SimpleTurbine.mo
@@ -21,7 +21,7 @@ model SimpleTurbine "Model of a hydropower system with a simple turbine turbine"
     D_o=3,
     H=80,
     L=200,
-    vertical=true) constrainedby Interfaces.TwoContacts annotation (Placement(transformation(origin={0,30}, extent={{-10,-10},{10,10}})));
+    slanted=true) constrainedby Interfaces.TwoContacts annotation (Placement(transformation(origin={0,30}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank(H=25, L=30, h_0=20)
     annotation (Placement(transformation(
         origin={-30,30},

--- a/OpenHPL/Examples/SimpleValve.mo
+++ b/OpenHPL/Examples/SimpleValve.mo
@@ -21,7 +21,7 @@ model SimpleValve "Model of a hydropower system with a simple turbine turbine"
     D_o=3,
     H=80,
     L=200,
-    vertical=true) constrainedby Interfaces.TwoContacts annotation (Placement(transformation(origin={0,30}, extent={{-10,-10},{10,10}})));
+    slanted=true) constrainedby Interfaces.TwoContacts annotation (Placement(transformation(origin={0,30}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank(
     H=25,
     L=30,

--- a/OpenHPL/Examples/WithOpenIPSL/DetailedGen.mo
+++ b/OpenHPL/Examples/WithOpenIPSL/DetailedGen.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Examples.WithOpenIPSL;
 model DetailedGen
   extends SimpleGen(       redeclare Waterway.PenstockKP penstock(
-      vertical=true,
+      slanted=true,
       H=428.5,
       D_i=3), data(SteadyState=false));
   annotation (experiment(StopTime=2000));

--- a/OpenHPL/Examples/WithOpenIPSL/SimpleGen.mo
+++ b/OpenHPL/Examples/WithOpenIPSL/SimpleGen.mo
@@ -16,7 +16,7 @@ model SimpleGen "Synergy with OpenIPSL library(generator)"
         rotation=180)));
   replaceable
   Waterway.Pipe penstock(
-    vertical=true,
+    slanted=true,
     L=600,
     H=428.5,
     D_i=3) constrainedby Interfaces.TwoContacts

--- a/OpenHPL/Examples/WithOpenIPSL/SimpleGenTG.mo
+++ b/OpenHPL/Examples/WithOpenIPSL/SimpleGenTG.mo
@@ -17,7 +17,7 @@ model SimpleGenTG "Synergy with OpenIPSL library(generator)"
         rotation=180)));
   replaceable
   Waterway.Pipe penstock(
-    vertical=true,
+    slanted=true,
     L=600,
     H=428.5,
     D_i=3) constrainedby Interfaces.TwoContacts

--- a/OpenHPL/Icons/Pipe.mo
+++ b/OpenHPL/Icons/Pipe.mo
@@ -1,6 +1,6 @@
 within OpenHPL.Icons;
 partial class Pipe "Pipe icon"
-  parameter Boolean vertical=false "Display vertical icon instead"
+  parameter Boolean slanted=false "Display slanted icon instead"
     annotation(Dialog(group = "Icon"),
     choices(checkBox = true));
   annotation (
@@ -11,37 +11,37 @@ partial class Pipe "Pipe icon"
           lineColor={0,0,0},
           fillPattern=FillPattern.Solid,
           fillColor={175,175,175},
-          visible=not vertical),
+          visible=not slanted),
         Rectangle(
           extent={{-90,30},{90,-30}},
           lineColor={28,108,200},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
-          visible=not vertical),
+          visible=not slanted),
         Rectangle(
           extent={{-85,30},{85,-30}},
           lineColor={0,0,0},
           fillPattern=FillPattern.Solid,
           fillColor={175,175,175},
           rotation=-45,
-          visible=vertical),
+          visible=slanted),
         Rectangle(
           extent={{-85,20},{85,-20}},
           lineColor={28,108,200},
           fillColor={0,128,255},
           fillPattern=FillPattern.Solid,
           rotation=-45,
-          visible=vertical),
+          visible=slanted),
         Text(
           textColor={28,108,200},
           extent={{-150,140},{150,100}},
           textString="%name",
           textStyle={TextStyle.Bold},
-          visible=vertical),
+          visible=slanted),
         Text(
           textColor={28,108,200},
           extent={{-150,90},{150,50}},
           textString="%name",
           textStyle={TextStyle.Bold},
-          visible=not vertical)}));
+          visible=not slanted)}));
 end Pipe;

--- a/OpenHPL/Waterway/Penstock.mo
+++ b/OpenHPL/Waterway/Penstock.mo
@@ -2,7 +2,7 @@ within OpenHPL.Waterway;
 model Penstock "Model of the penstock with elastic walls and compressible water. Simple Staggered grid scheme"
   extends Modelica.Icons.ObsoleteModel;
   outer Data data "Using standard data set";
-  extends OpenHPL.Icons.Pipe(vertical=true);
+  extends OpenHPL.Icons.Pipe(slanted=true);
   import Modelica.Constants.pi;
   // Penstock
   parameter SI.Height H = 420 "Height over which water fall in the pipe, m" annotation (

--- a/OpenHPL/Waterway/PenstockKP.mo
+++ b/OpenHPL/Waterway/PenstockKP.mo
@@ -1,7 +1,7 @@
 within OpenHPL.Waterway;
 model PenstockKP "Detailed model of the pipe. Could have elastic walls and compressible water. KP scheme"
   outer OpenHPL.Data data "Using standard data set";
-  extends OpenHPL.Icons.Pipe( vertical=true);
+  extends OpenHPL.Icons.Pipe( slanted=true);
   extends Types.FrictionSpec(   final D_h = (D_i + D_o) / 2);
   import Modelica.Constants.pi;
   // geometrical parameters of the pipe

--- a/OpenHPLTest/HPAllTypeFittingsTest.mo
+++ b/OpenHPLTest/HPAllTypeFittingsTest.mo
@@ -60,7 +60,7 @@ model HPAllTypeFittingsTest "Test for comparing fitting behaviour"
     L=100,
     D_i=4) annotation (Placement(transformation(extent={{40,-30},{60,-10}})));
   OpenHPL.Waterway.Pipe pipe6(
-    vertical=false,
+    slanted=false,
     H=5,
     L=100,
     D_i=4) annotation (Placement(transformation(extent={{-60,-50},{-40,-30}})));

--- a/OpenHPLTest/HPDraftTube.mo
+++ b/OpenHPLTest/HPDraftTube.mo
@@ -21,7 +21,7 @@ model HPDraftTube "Testing the draft tube models."
     D_o=3,
     H=428.5,
     L=600,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={2,50},
         extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank(h_0=69.9) annotation (Placement(transformation(
@@ -48,7 +48,7 @@ model HPDraftTube "Testing the draft tube models."
     D_o=3,
     H=428.5,
     L=600,
-    vertical=true) annotation (Placement(transformation(origin={0,-10}, extent={{-10,-10},{10,10}})));
+    slanted=true) annotation (Placement(transformation(origin={0,-10}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank1(h_0=69.9) annotation (Placement(transformation(origin={-30,-10}, extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine1(C_v=3.7, ConstEfficiency=false) annotation (Placement(transformation(origin={30,-20}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.DraftTube draftTube1(
@@ -74,7 +74,7 @@ model HPDraftTube "Testing the draft tube models."
     D_o=3,
     H=428.5,
     L=600,
-    vertical=true) annotation (Placement(transformation(origin={2,-70}, extent={{-10,-10},{10,10}})));
+    slanted=true) annotation (Placement(transformation(origin={2,-70}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank2(h_0=69.9) annotation (Placement(transformation(origin={-30,-70}, extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine2(C_v=3.7, ConstEfficiency=false) annotation (Placement(transformation(origin={32,-80}, extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.DraftTube draftTube2(

--- a/OpenHPLTest/HPSTAirCushion.mo
+++ b/OpenHPLTest/HPSTAirCushion.mo
@@ -30,7 +30,7 @@ model HPSTAirCushion
     D_o=4,
     H=300,
     L=500,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine(

--- a/OpenHPLTest/HPSTSharpOrifice.mo
+++ b/OpenHPLTest/HPSTSharpOrifice.mo
@@ -30,7 +30,7 @@ model HPSTSharpOrifice
     D_o=4,
     H=300,
     L=500,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine(

--- a/OpenHPLTest/HPSTSimple.mo
+++ b/OpenHPLTest/HPSTSimple.mo
@@ -30,7 +30,7 @@ model HPSTSimple
     D_o=4,
     H=300,
     L=500,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine(

--- a/OpenHPLTest/HPSTThrottleValve.mo
+++ b/OpenHPLTest/HPSTThrottleValve.mo
@@ -30,7 +30,7 @@ model HPSTThrottleValve
     D_o=4,
     H=300,
     L=500,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));
   OpenHPL.ElectroMech.Turbines.Turbine turbine(

--- a/OpenHPLTest/HPTaperedFittingsTest.mo
+++ b/OpenHPLTest/HPTaperedFittingsTest.mo
@@ -8,7 +8,7 @@ model HPTaperedFittingsTest "Test for comparing fitting behaviour"
     D_o=4,
     L=4) annotation (Placement(transformation(extent={{-10,50},{10,70}})));
   OpenHPL.Waterway.Pipe pipe1(
-    vertical=false,
+    slanted=false,
     H=5,
     L=100,
     D_i=2) annotation (Placement(transformation(extent={{-60,50},{-40,70}})));

--- a/OpenHPLTest/TorpaHPPAirCushionTest.mo
+++ b/OpenHPLTest/TorpaHPPAirCushionTest.mo
@@ -24,7 +24,7 @@ model TorpaHPPAirCushionTest "Test case for air cushion surge tank from Torpa hy
     D_o=6.56,
     H=8.6,
     L=250,
-    vertical=true,
+    slanted=true,
     p_eps=0.005) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));

--- a/OpenHPLTest/TorpaHPPAirCushionTest2.mo
+++ b/OpenHPLTest/TorpaHPPAirCushionTest2.mo
@@ -17,7 +17,7 @@ model TorpaHPPAirCushionTest2 "Test case for air cushion surge tank from Torpa h
     D_o=3,
     H=428.5,
     L=600,
-    vertical=true) annotation (Placement(transformation(
+    slanted=true) annotation (Placement(transformation(
         origin={0,30},
         extent={{-10,-10},{10,10}})));
   OpenHPL.Waterway.SurgeTank surgeTank(h_0=69.9) annotation (Placement(transformation(


### PR DESCRIPTION
Updates the `vertical` boolean parameter across pipe models and their corresponding icons to `slanted`. This refactoring improves the semantic clarity of the parameter, better describing the orientation of pipes that are not horizontal.
